### PR TITLE
WIP: revised Bart's datasets

### DIFF
--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -137,7 +137,6 @@ class ContainerDataset(Dataset):
 
     """
     default_scheme = None
-    sources = ("data")
 
     def __init__(self, container):
         if isinstance(container, dict):
@@ -189,6 +188,9 @@ class DataStream(object):
 
     def __init__(self, iteration_scheme=None):
         self.iteration_scheme = iteration_scheme
+        self._reset_request_iterator()
+
+    def _reset_request_iterator(self):
         self.request_iterator = (iter(self.iteration_scheme)
                                  if self.iteration_scheme
                                  else None)
@@ -233,8 +235,8 @@ class DataStream(object):
     def epochs(self):
         """Allow iteration through all epochs."""
         while True:
-            self.next_epoch()
             yield self
+            self.next_epoch()
 
 
 class InitialDataStream(DataStream):
@@ -274,6 +276,10 @@ class InitialDataStream(DataStream):
 
     def next_epoch(self):
         self.data_state = self.dataset.next_epoch(self.data_state)
+        # TODO: switching to the next epoch should not just reset
+        # request iterator. It should switch to the request
+        # stream of the next epoch.
+        self._reset_request_iterator()
 
     def get_data(self, request):
         """Get data from the dataset."""
@@ -298,6 +304,10 @@ class WrapperDataStream(DataStream):
 
     def next_epoch(self):
         self.data_stream.next_epoch()
+        # TODO: switching to the next epoch should not just reset
+        # request iterator. It should switch to the request
+        # stream of the next epoch.
+        self._reset_request_iterator()
 
     def get_data(self, request):
         """Get data from the wrapped data stream.

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,4 +1,6 @@
-from blocks.datasets import ContainerDataset, MappingDataStream
+from blocks.datasets import (ContainerDataset, InitialDataStream,
+                             MappingDataStream)
+from blocks.datasets.schemes import BatchSizeScheme, ConstantScheme
 from collections import OrderedDict
 
 
@@ -8,6 +10,7 @@ def test_dataset():
     stream = ContainerDataset([1, 2, 3]).open_stream()
     assert list(stream) == list(zip(data))
 
+    stream.reset()
     for i, epoch in zip(range(3), stream.epochs()):
         assert list(epoch) == list(zip(data))
 
@@ -31,3 +34,54 @@ def test_sources_selection():
     stream.sources = ("targets",)
     stream.reset()
     assert list(stream) == list(zip(targets))
+
+
+def test_data_driven_epochs():
+
+    class TestDataset(ContainerDataset):
+
+        sources = "data"
+        default_scheme = ConstantScheme(1)
+
+        def __init__(self):
+            self.data = [[1, 2, 3, 4],
+                         [5, 6, 7, 8]]
+
+        def open(self):
+            epoch_iter = iter(self.data)
+            data_iter = iter(next(epoch_iter))
+            return (epoch_iter, data_iter)
+
+        def next_epoch(self, state):
+            data_iter = iter(next(state[0]))
+            return (state[0], data_iter)
+
+        def get_data(self, state, request, sources):
+            data = []
+            for i in range(request):
+                data.append(next(state[1]))
+            return (data,)
+
+    epochs = []
+    epochs.append([([1],), ([2],), ([3],), ([4],)])
+    epochs.append([([5],), ([6],), ([7],), ([8],)])
+    stream = TestDataset().open_stream()
+    assert list(stream) == epochs[0]
+    stream.next_epoch()
+    assert list(stream) == epochs[1]
+    stream.reset()
+    for i, epoch in enumerate(stream.epochs()):
+        assert list(epoch) == epochs[i]
+
+    # test scheme reseting between epochs
+    class TestScheme(BatchSizeScheme):
+
+        def __iter__(self):
+            return iter([1, 2, 1, 3])
+
+    epochs = []
+    epochs.append([([1],), ([2, 3],), ([4],)])
+    epochs.append([([5],), ([6, 7],), ([8],)])
+    stream = InitialDataStream(TestDataset(), TestScheme())
+    for i, epoch in enumerate(stream.epochs()):
+        assert list(epoch) == epochs[i]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,15 +1,33 @@
 from blocks.datasets import ContainerDataset, MappingDataStream
+from collections import OrderedDict
 
 
 def test_dataset():
     data = [1, 2, 3]
     data2 = [2, 4, 6]
     stream = ContainerDataset([1, 2, 3]).open_stream()
-    assert list(stream) == data
+    assert list(stream) == list(zip(data))
 
     for i, epoch in zip(range(3), stream.epochs()):
-        assert list(epoch) == data
+        assert list(epoch) == list(zip(data))
 
-    wrapper = MappingDataStream(stream, lambda x: x * 2)
+    stream.reset()
+    assert stream.next_as_dict() == {"data": 1}
+
+    wrapper = MappingDataStream(
+        stream, lambda d: (2 * d[0],))
     wrapper.reset()
-    assert list(wrapper) == data2
+    assert list(wrapper) == list(zip(data2))
+
+
+def test_sources_selection():
+    features = [5, 6, 7, 1]
+    targets = [1, 0, 1, 1]
+    stream = ContainerDataset(
+        OrderedDict([("features", features),
+                     ("targets", targets)])).open_stream()
+    assert list(stream) == list(zip(features, targets))
+
+    stream.sources = ("targets",)
+    stream.reset()
+    assert list(stream) == list(zip(targets))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,15 @@
+from blocks.datasets import ContainerDataset, MappingDataStream
+
+
+def test_dataset():
+    data = [1, 2, 3]
+    data2 = [2, 4, 6]
+    stream = ContainerDataset([1, 2, 3]).open_stream()
+    assert list(stream) == data
+
+    for i, epoch in zip(range(3), stream.epochs()):
+        assert list(epoch) == data
+
+    wrapper = MappingDataStream(stream, lambda x: x * 2)
+    wrapper.reset()
+    assert list(wrapper) == data2


### PR DESCRIPTION
Here comes my revision of Bart's dataset proposal. The main changes are:

* I distinguish between two types of data streams, those that originate directly from a dataset and those that wrap existing ones. The former inherit from `InitialDataStream`, while the latter are descendants of `WrapperDataStream`.

* I change the interface to make a data stream behave just like Python file objects with an additional `next_epoch` method. As a consequence, the `__iter__` method does not reset iteration anymore.

Main open questions:

* do we actually need sources specification for the wrapping data streams? Perhaps it would be always enough to choose data sources when constructing the first data stream of the pipeline? 

* ~~some dataset states might turn out to be not picklable, e.g. a Python file can not be picked. Thus we need to add state serialization and deserialization routines to the `Dataset`, that by default will use pickling but can be overriden. E.g. for a file it is sufficient to remember the position in it. In addition we need to add smth like `is_pickable` to the `DataStream` interface.~~ By overloading `__getstate__` and `__setstate__` of the dataset's state we can ensure that the state is always serializable.

* iteration schemes should be extended to be able to span across several epochs. Adding smth like `next_epoch` method that will be called by the `next_epoch` method of a data stream should do the job.

* ~~I am not sure that a tuple is the best format for the data produced by a data stream. I would prefer something named, e.g. a named tuple or even a dict.~~ Perhaps a tuple is a good inner representation, a dict may be returned on request.
