### PR TITLE
BinaryCrossEntropy to work with indices direcly

### DIFF
--- a/blocks/bricks/cost.py
+++ b/blocks/bricks/cost.py
@@ -25,6 +25,15 @@ class BinaryCrossEntropy(CostMatrix):
         cost = tensor.nnet.binary_crossentropy(y_hat, y)
         return cost
 
+    @application
+    def apply_for_indices(self, y_ones_indices, y_hat):
+        flat_ones_indices = y_ones_indices.flatten()
+        return -(tensor.log(
+            y_hat.flatten()
+                [y_hat.shape[-1]
+                 * tensor.arange(flat_ones_indices.shape[0])
+                 + flat_ones_indices])).mean()
+
 
 class AbsoluteError(CostMatrix):
     @application


### PR DESCRIPTION
As far as I understand the PyLearn2'ish way of computing cross-entropy was to transform indices into one-hot vectors. I am afraid that this is rather memory inefficient, especially for a large number of classes. This pull request introduces a method that bypasses one-hot vectors and works with indices directly.

As the whole `cost.py` currently misses documentation, I did not document what the method does.

In case you case support this initiative, I will cover it by a test before merging.