### PR TITLE
as_dict for epochs

### DIFF
--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -238,8 +238,7 @@ class AbstractDataStream(object):
                             if self.iteration_scheme else None,
                             as_dict=as_dict)
 
-    @property
-    def epochs(self):
+    def epochs(self, as_dict=False):
         """Allow iteration through all epochs.
 
         Notes
@@ -256,7 +255,7 @@ class AbstractDataStream(object):
 
         """
         while True:
-            yield self.get_epoch_iterator()
+            yield self.get_epoch_iterator(as_dict=as_dict)
 
 
 class DataStream(AbstractDataStream):

--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -238,7 +238,7 @@ class AbstractDataStream(object):
                             if self.iteration_scheme else None,
                             as_dict=as_dict)
 
-    def epochs(self, as_dict=False):
+    def iterate_epochs(self, as_dict=False):
         """Allow iteration through all epochs.
 
         Notes

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -16,9 +16,9 @@ def test_dataset():
     assert list(epoch) == list(zip(data))
 
     # Check if iterating over multiple epochs works
-    for i, epoch in zip(range(2), stream.epochs()):
+    for i, epoch in zip(range(2), stream.iterate_epochs()):
         assert list(epoch) == list(zip(data))
-    for i, epoch in enumerate(stream.epochs()):
+    for i, epoch in enumerate(stream.iterate_epochs()):
         assert list(epoch) == list(zip(data))
         if i == 1:
             break
@@ -82,7 +82,7 @@ def test_data_driven_epochs():
     assert list(stream.get_epoch_iterator()) == epochs[0]
 
     stream.reset()
-    for i, epoch in zip(range(2), stream.epochs()):
+    for i, epoch in zip(range(2), stream.iterate_epochs()):
         assert list(epoch) == epochs[i]
 
     # test scheme reseting between epochs
@@ -95,5 +95,5 @@ def test_data_driven_epochs():
     epochs.append([([1],), ([2, 3],), ([4],)])
     epochs.append([([5],), ([6, 7],), ([8],)])
     stream = DataStream(TestDataset(), iteration_scheme=TestScheme())
-    for i, epoch in zip(range(2), stream.epochs()):
+    for i, epoch in zip(range(2), stream.iterate_epochs()):
         assert list(epoch) == epochs[i]

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -16,9 +16,9 @@ def test_dataset():
     assert list(epoch) == list(zip(data))
 
     # Check if iterating over multiple epochs works
-    for i, epoch in zip(range(2), stream.epochs):
+    for i, epoch in zip(range(2), stream.epochs()):
         assert list(epoch) == list(zip(data))
-    for i, epoch in enumerate(stream.epochs):
+    for i, epoch in enumerate(stream.epochs()):
         assert list(epoch) == list(zip(data))
         if i == 1:
             break
@@ -82,7 +82,7 @@ def test_data_driven_epochs():
     assert list(stream.get_epoch_iterator()) == epochs[0]
 
     stream.reset()
-    for i, epoch in zip(range(2), stream.epochs):
+    for i, epoch in zip(range(2), stream.epochs()):
         assert list(epoch) == epochs[i]
 
     # test scheme reseting between epochs
@@ -95,5 +95,5 @@ def test_data_driven_epochs():
     epochs.append([([1],), ([2, 3],), ([4],)])
     epochs.append([([5],), ([6, 7],), ([8],)])
     stream = DataStream(TestDataset(), iteration_scheme=TestScheme())
-    for i, epoch in zip(range(2), stream.epochs):
+    for i, epoch in zip(range(2), stream.epochs()):
         assert list(epoch) == epochs[i]


### PR DESCRIPTION
An interface fix. It is more convenient to request data as dictionaries for the main loop.