### PR TITLE
WIP: First version of lazy properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
 script:
   - |
       if [ $TESTS ]; then
-        THEANO_FLAGS=floatX=$TESTS,blas.ldflags='-lblas -lgfortran' \
+        export THEANO_FLAGS=floatX=$TESTS,blas.ldflags='-lblas -lgfortran'
         # Running nose2 within coverage makes imports count towards coverage
         coverage run --source=blocks -m nose2.__main__ tests
       fi

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -1028,6 +1028,8 @@ def _activation_factory(name, activation):
     class ActivationDocumentation(type):
         def __new__(cls, name, bases, classdict):
             classdict['__doc__'] = classdict['__doc__'].format(name.lower())
+            classdict['apply'].__doc__ = \
+                classdict['apply'].__doc__.format(name.lower())
             return type.__new__(cls, name, bases, classdict)
 
     @add_metaclass(ActivationDocumentation)
@@ -1051,8 +1053,6 @@ def _activation_factory(name, activation):
             output = activation(input_)
             return output
     Activation.__name__ = name
-    Activation.apply.__doc__ = \
-        Activation.apply.__doc__.format(name.lower())
     return Activation
 
 Identity = _activation_factory('Identity', lambda x: x)

--- a/blocks/config_parser.py
+++ b/blocks/config_parser.py
@@ -71,7 +71,7 @@ class Configuration(object):
                     self.config[key]['yaml'] = value
 
     def __getattr__(self, key):
-        if not hasattr(self, 'config') or key not in self.config:
+        if key == 'config' or key not in self.config:
             raise AttributeError
         config = self.config[key]
         if 'value' in config:
@@ -88,10 +88,10 @@ class Configuration(object):
         return config['type'](value)
 
     def __setattr__(self, key, value):
-        if not hasattr(self, 'config') or key not in self.config:
-            super(Configuration, self).__setattr__(key, value)
-        else:
+        if key != 'config' and key in self.config:
             self.config[key]['value'] = value
+        else:
+            super(Configuration, self).__setattr__(key, value)
 
     def add_config(self, key, type_, default=NOT_SET, env_var=None):
         """Add a configuration setting.

--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -158,9 +158,9 @@ class InMemoryDataset(Dataset):
     >>> import pickle
     >>> from blocks.datasets.mnist import MNIST
     >>> mnist = MNIST('train')
-    >>> print("{} MB".format(
-    ...     mnist.data['features'].nbytes // 1024 // 1024)) # doctest: +SKIP
-    179 MB
+    >>> print("{:,d} KB".format(
+    ...     mnist.data['features'].nbytes / 1024)) # doctest: +SKIP
+    183,750 KB
     >>> with open('mnist.pkl', 'wb') as f:
     ...     pickle.dump(mnist, f, protocol=pickle.HIGHEST_PROTOCOL)
 

--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -169,7 +169,7 @@ class InMemoryDataset(Dataset):
     and if the data file has not been moved, it will be as if nothing
     happened.
 
-    >>> with open('mnist.pkl') as f:
+    >>> with open('mnist.pkl', 'rb') as f:
     ...     mnist = pickle.load(f)
     >>> print(mnist.data['features'].shape)
     (60000, 784)
@@ -180,7 +180,7 @@ class InMemoryDataset(Dataset):
     >>> from blocks import config
     >>> correct_path = config.data_path
     >>> config.data_path = '/non/existing/path'
-    >>> with open('mnist.pkl') as f:
+    >>> with open('mnist.pkl', 'rb') as f:
     ...     mnist = pickle.load(f)
     >>> print("{} KB".format(mnist.data['features'].nbytes // 1024))
     Traceback (most recent call last):

--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -182,10 +182,10 @@ class InMemoryDataset(Dataset):
     >>> config.data_path = '/non/existing/path'
     >>> with open('mnist.pkl', 'rb') as f:
     ...     mnist = pickle.load(f)
-    >>> print("{} KB".format(mnist.data['features'].nbytes // 1024))
+    >>> print(mnist.data['features'].shape) # doctest: +SKIP
     Traceback (most recent call last):
       ...
-    IOError: [Errno 2] No such file or directory: ...
+    FileNotFoundError: [Errno 2] No such file or directory: ...
 
     Because the loading happens lazily, we can still deserialize our
     dataset, correct the situation, and then continue.

--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -216,6 +216,36 @@ class InMemoryDataset(Dataset):
 
 
 def lazy_properties(*lazy_properties):
+    r"""Decorator to assign lazy properties.
+
+    Used to assign "lazy properties" on :class:`InMemoryDataset` classes.
+    Please see the documentation there for a discussion on what lazy
+    properties are and why they are needed.
+
+    Parameters
+    ----------
+    \*lazy_properties : strings
+        The names of the attributes that are lazy.
+
+    Notes
+    -----
+    The pickling behaviour of the dataset is only overridden if the dataset
+    does not have a ``__getstate__`` method implemented.
+
+    Examples
+    --------
+    In order to make sure that attributes are not serialized with the
+    dataset, and are lazily reloaded by the :meth:`~InMemoryDataset.load`
+    method after deserialization, use the decorator with the names of the
+    attributes as an argument.
+
+    >>> @lazy_properties('features', 'targets')
+    ... class TestDataset(InMemoryDataset):
+    ...     def load(self):
+    ...         self.features = range(10 ** 6)
+    ...         self.targets = range(10 ** 6)[::-1]
+
+    """
     def lazy_property_factory(lazy_property):
         """Create properties that perform lazy loading of attributes."""
         def lazy_property_getter(self):

--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -170,8 +170,8 @@ class InMemoryDataset(Dataset):
 
     >>> with open('mnist.pkl') as f:
     ...     mnist = cPickle.load(f)
-    >>> print("{} MB".format(mnist.data['features'].nbytes / 1024 / 1024))
-    179 MB
+    >>> print(mnist.data['features'].shape)
+    (60000, 784)
 
     However, if the data files can't be found on disk, accessing the data
     will fail.
@@ -190,8 +190,8 @@ class InMemoryDataset(Dataset):
     dataset, correct the situation, and then continue.
 
     >>> config.data_path = correct_path
-    >>> print("{} MB".format(mnist.data['features'].nbytes / 1024 / 1024))
-    179 MB
+    >>> print(mnist.data['features'].shape)
+    (60000, 784)
 
     """
     def load(self):

--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -165,8 +165,7 @@ def lazy_properties(*lazy_properties):
             def __getstate__(self):
                 for lazy_property in lazy_properties:
                     attr = getattr(self, '_' + lazy_property)
-                    if isinstance(attr, collections.Iterator) and \
-                            not hasattr(attr, 'read'):
+                    if isinstance(attr, collections.Iterator):
                         raise ValueError("Iterators can't be lazy loaded")
                     delattr(self, '_' + lazy_property)
                 return self.__dict__

--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -155,13 +155,14 @@ class InMemoryDataset(Dataset):
     files are loaded after de-serialization, before the :meth:`load` method
     is ever called.
 
-    >>> import cPickle
+    >>> import pickle
     >>> from blocks.datasets.mnist import MNIST
     >>> mnist = MNIST('train')
-    >>> print("{} MB".format(mnist.data['features'].nbytes / 1024 / 1024))
+    >>> print("{} MB".format(
+    ...     mnist.data['features'].nbytes // 1024 // 1024)) # doctest: +SKIP
     179 MB
     >>> with open('mnist.pkl', 'wb') as f:
-    ...     cPickle.dump(mnist, f, protocol=cPickle.HIGHEST_PROTOCOL)
+    ...     pickle.dump(mnist, f, protocol=pickle.HIGHEST_PROTOCOL)
 
     You will notice that the dumping of the dataset was relatively quick,
     because it didn't attempt to write MNIST to disk. We can now reload it,
@@ -169,7 +170,7 @@ class InMemoryDataset(Dataset):
     happened.
 
     >>> with open('mnist.pkl') as f:
-    ...     mnist = cPickle.load(f)
+    ...     mnist = pickle.load(f)
     >>> print(mnist.data['features'].shape)
     (60000, 784)
 
@@ -180,8 +181,8 @@ class InMemoryDataset(Dataset):
     >>> correct_path = config.data_path
     >>> config.data_path = '/non/existing/path'
     >>> with open('mnist.pkl') as f:
-    ...     mnist = cPickle.load(f)
-    >>> print("{} MB".format(mnist.data['features'].nbytes / 1024 / 1024))
+    ...     mnist = pickle.load(f)
+    >>> print("{} KB".format(mnist.data['features'].nbytes // 1024))
     Traceback (most recent call last):
       ...
     IOError: [Errno 2] No such file or directory: ...
@@ -192,6 +193,13 @@ class InMemoryDataset(Dataset):
     >>> config.data_path = correct_path
     >>> print(mnist.data['features'].shape)
     (60000, 784)
+
+    .. doctest::
+       :hide:
+
+       >>> import os
+       >>> os.remove('mnist.pkl')
+
 
     """
     def load(self):

--- a/blocks/datasets/mnist.py
+++ b/blocks/datasets/mnist.py
@@ -5,14 +5,16 @@ import numpy
 import theano
 
 from blocks import config
-from blocks.datasets import Dataset
+from blocks.datasets import Dataset, lazy_properties
 from blocks.datasets.schemes import SequentialScheme
+from blocks.utils import update_instance
 
 
 MNIST_IMAGE_MAGIC = 2051
 MNIST_LABEL_MAGIC = 2049
 
 
+@lazy_properties('data')
 class MNIST(Dataset):
     """The MNIST dataset of handwritten digits.
 
@@ -49,30 +51,35 @@ class MNIST(Dataset):
 
     def __init__(self, which_set, start=None, stop=None, binary=False,
                  **kwargs):
-        if which_set == 'train':
+        if which_set not in ('train', 'test'):
+            raise ValueError("MNIST only has a train and test set")
+        num_examples = (stop if stop else 60000) - (start if start else 0)
+        default_scheme = SequentialScheme(num_examples, 1)
+        update_instance(self, locals())
+        super(MNIST, self).__init__(**kwargs)
+
+    def load(self):
+        if self.which_set == 'train':
             data = 'train-images-idx3-ubyte'
             labels = 'train-labels-idx1-ubyte'
-        elif which_set == 'test':
+        elif self.which_set == 'test':
             data = 't10k-images-idx3-ubyte'
             labels = 't10k-labels-idx1-ubyte'
-        else:
-            raise ValueError("MNIST only has a train and test set")
         data_path = os.path.join(config.data_path, 'mnist')
         X = read_mnist_images(
             os.path.join(data_path, data),
-            'bool' if binary else theano.config.floatX)[start:stop]
+            'bool' if self.binary
+            else theano.config.floatX)[self.start:self.stop]
         X = X.reshape((X.shape[0], numpy.prod(X.shape[1:])))
         y = read_mnist_labels(
-            os.path.join(data_path, labels))[start:stop, numpy.newaxis]
-        self.X, self.y = X, y
-        self.num_examples = len(X)
-        self.default_scheme = SequentialScheme(self.num_examples, 1)
-        super(MNIST, self).__init__(**kwargs)
+            os.path.join(data_path, labels))[self.start:self.stop,
+                                             numpy.newaxis]
+        self.data = {'features': X, 'targets': y}
 
     def get_data(self, state=None, request=None):
-        assert state is None
-        data = dict(zip(('features', 'targets'), (self.X, self.y)))
-        return tuple(data[source][request] for source in self.sources)
+        if state is not None:
+            raise ValueError("MNIST does not have a state")
+        return tuple(self.data[source][request] for source in self.sources)
 
 
 def read_mnist_images(filename, dtype=None):

--- a/blocks/datasets/mnist.py
+++ b/blocks/datasets/mnist.py
@@ -5,7 +5,7 @@ import numpy
 import theano
 
 from blocks import config
-from blocks.datasets import Dataset, lazy_properties
+from blocks.datasets import InMemoryDataset, lazy_properties
 from blocks.datasets.schemes import SequentialScheme
 from blocks.utils import update_instance
 
@@ -15,7 +15,7 @@ MNIST_LABEL_MAGIC = 2049
 
 
 @lazy_properties('data')
-class MNIST(Dataset):
+class MNIST(InMemoryDataset):
     """The MNIST dataset of handwritten digits.
 
     .. todo::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
     'sphinxcontrib.napoleon',
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -5,11 +5,11 @@ from blocks.datasets.mnist import MNIST
 
 def test_mnist():
     mnist_train = MNIST('train', start=20000)
-    assert len(mnist_train.X) == 40000
-    assert len(mnist_train.y) == 40000
+    assert len(mnist_train.data['features']) == 40000
+    assert len(mnist_train.data['targets']) == 40000
     mnist_test = MNIST('test', sources=('targets',))
-    assert len(mnist_test.X) == 10000
-    assert len(mnist_test.y) == 10000
+    assert len(mnist_test.data['features']) == 10000
+    assert len(mnist_test.data['targets']) == 10000
 
     first_feature, first_target = mnist_train.get_data(request=[0])
     assert first_feature.shape == (1, 784)

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -1,4 +1,7 @@
+import numpy
 from numpy.testing import assert_raises
+
+import theano
 
 from blocks.datasets.mnist import MNIST
 
@@ -13,7 +16,9 @@ def test_mnist():
 
     first_feature, first_target = mnist_train.get_data(request=[0])
     assert first_feature.shape == (1, 784)
+    assert first_feature.dtype is numpy.dtype(theano.config.floatX)
     assert first_target.shape == (1, 1)
+    assert first_target.dtype is numpy.dtype('uint8')
 
     first_target, = mnist_test.get_data(request=[0, 1])
     assert first_target.shape == (2, 1)

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -19,16 +19,21 @@ def test_config_parser():
         config.add_config('config_with_default', int, default='1',
                           env_var='BLOCKS_CONFIG_TEST')
         config.add_config('config_without_default', str)
+        config.load_yaml()
         assert config.data_path == 'yaml_path'
         os.environ['BLOCKS_DATA_PATH'] = 'env_path'
         assert config.data_path == 'env_path'
         assert config.config_with_default == 1
         os.environ['BLOCKS_CONFIG_TEST'] = '2'
         assert config.config_with_default == 2
-        assert_raises(ConfigurationError, getattr, config,
+        assert_raises(AttributeError, getattr, config,
                       'non_existing_config')
         assert_raises(ConfigurationError, getattr, config,
                       'config_without_default')
+        config.data_path = 'manual_path'
+        assert config.data_path == 'manual_path'
+        config.new_config = 'new_config'
+        assert config.new_config == 'new_config'
     finally:
         os.remove(os.environ['BLOCKS_CONFIG'])
         os.environ.clear()


### PR DESCRIPTION
**Update:** Just to be clear what the goal is here: The easy approach to stopping and resuming training is by simply dumping the `MainLoop` object in a pickle file. However, this would result in pickling any data held in memory by `DataSet` instances. To prevent that, this introduces a way of making sure that this data is transparently removed from memory before serializing, and reloading it again after deserialization. However, this reloading is done lazily, so that the user has time to intervene in case files have moved around or disappeared.

-----

Because many datasets will have the same approach I endeavored to automate some parts of dataset serialization.

This PR introduces a `lazy_properties` decorator which allows you to name properties which are "lazy". This means that they will be loaded by a call to `load`, and `load` will only be called the first time one of the properties is actually needed. Moreover, when the dataset is serialized the `__getstate__` method will remove all of the lazy properties so that they don't get pickled. When de-serializing, `load` won't be called again until one of the lazy properties is requested.

One shortcoming of this implementation is if *one* lazy property is requested, *all* will be loaded. I don't think that this is actually an issue though. The only thing we need is that they don't get loaded during de-serialization so that a user can fix the state of the dataset instance in case files have moved around.

I don't allow lazy loading of iterators, because their state would be lost, except for file handles (which should be handled through `dill` or our own implementation; I'll implement that soon). WIP because all tests and documentation are missing as of yet.

Fixes #96.