### PR TITLE
Serializable datasets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
 script:
   - |
       if [ $TESTS ]; then
-        python setup.py install -q # Tests setup.py (also installs dill)
+        python setup.py -q install # Tests setup.py (also installs dill)
         # Must export environment variable so that the subprocess is aware of it
         export THEANO_FLAGS=floatX=$TESTS,blas.ldflags='-lblas -lgfortran'
         # Running nose2 within coverage makes imports count towards coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ install:
 script:
   - |
       if [ $TESTS ]; then
-        python setup.py install # Tests setup.py (also installs dill)
+        python setup.py install -q # Tests setup.py (also installs dill)
+        # Must export environment variable so that the subprocess is aware of it
         export THEANO_FLAGS=floatX=$TESTS,blas.ldflags='-lblas -lgfortran'
         # Running nose2 within coverage makes imports count towards coverage
         coverage run --source=blocks -m nose2.__main__ tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,10 @@ install:
   - |
       if [ $TESTS ]; then
         conda install -q --yes python=$TRAVIS_PYTHON_VERSION nose numpy pip coverage six scipy
-        pip install -q --no-deps git+git://github.com/Theano/Theano.git
+        pip install -q --no-deps git+git://github.com/Theano/Theano.git # Development version
         pip install -q nose2[coverage-plugin] coveralls
-        git clone -q git://github.com/lisa-lab/pylearn2.git
-        (cd pylearn2
+        (git clone -q git://github.com/lisa-lab/pylearn2.git # Pylearn2 doesn't support pip
+        cd pylearn2
         python setup.py -q develop)
       fi
   - |
@@ -48,6 +48,7 @@ install:
 script:
   - |
       if [ $TESTS ]; then
+        python setup.py install # Tests setup.py (also installs dill)
         export THEANO_FLAGS=floatX=$TESTS,blas.ldflags='-lblas -lgfortran'
         # Running nose2 within coverage makes imports count towards coverage
         coverage run --source=blocks -m nose2.__main__ tests

--- a/blocks/datasets/schemes.py
+++ b/blocks/datasets/schemes.py
@@ -1,3 +1,4 @@
+import itertools
 from abc import ABCMeta, abstractmethod
 
 import six
@@ -69,26 +70,10 @@ class ConstantScheme(BatchSizeScheme):
         self.times = times
 
     def get_request_iterator(self):
-        return ConstantIterator(self.batch_size, self.times)
-
-
-class ConstantIterator(six.Iterator):
-    def __init__(self, batch_size, times=None):
-        self.batch_size = batch_size
-        self.times = times
-        if times is not None:
-            self.current = 0
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        if self.times is not None:
-            if self.current == self.times:
-                raise StopIteration
-            else:
-                self.current += 1
-        return self.batch_size
+        if self.times is None:
+            return itertools.repeat(self.batch_size)
+        else:
+            return itertools.repeat(self.batch_size, self.times)
 
 
 class SequentialScheme(BatchScheme):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     keywords='theano machine learning neural networks deep learning',
     packages=find_packages(exclude=['docs', 'tests']),
-    install_requires=['numpy', 'theano', 'six'],
+    install_requires=['dill', 'numpy', 'theano', 'six'],
     extras_require={
         'test': ['nose', 'nose2'],
     },

--- a/tests/datasets/test_serialization.py
+++ b/tests/datasets/test_serialization.py
@@ -17,16 +17,21 @@ def test_in_memory():
     for i, (features, targets) in enumerate(epoch):
         if i == 1:
             break
-    numpy.all(features == mnist.data['features'][256:512])
+    assert numpy.all(features == mnist.data['features'][256:512])
 
     # Pickle the epoch and make sure that the data wasn't dumped
-    with open('epoch_test.pkl', 'wb') as f:
+    filename = 'epoch_test.pkl'
+    assert not os.path.exists(filename)
+    with open(filename, 'wb') as f:
         dill.dump(epoch, f, protocol=dill.HIGHEST_PROTOCOL)
-    assert os.path.getsize('epoch_test.pkl') < 1024 * 1024  # Less than 1MB
+    assert os.path.getsize(filename) < 1024 * 1024  # Less than 1MB
 
     # Reload the epoch and make sure that the state was maintained
     del epoch
-    with open('epoch_test.pkl', 'rb') as f:
+    with open(filename, 'rb') as f:
         epoch = dill.load(f)
     features, targets = next(epoch)
     assert numpy.all(features == mnist.data['features'][512:768])
+
+    # Clean up
+    os.remove(filename)

--- a/tests/datasets/test_serialization.py
+++ b/tests/datasets/test_serialization.py
@@ -1,0 +1,32 @@
+import os
+
+import dill
+import numpy
+
+from blocks.datasets import DataStream
+from blocks.datasets.mnist import MNIST
+from blocks.datasets.schemes import SequentialScheme
+
+
+def test_in_memory():
+    # Load MNIST and get two batches
+    mnist = MNIST('train')
+    data_stream = DataStream(mnist, iteration_scheme=SequentialScheme(
+        num_examples=mnist.num_examples, batch_size=256))
+    epoch = data_stream.get_epoch_iterator()
+    for i, (features, targets) in enumerate(epoch):
+        if i == 1:
+            break
+    numpy.all(features == mnist.data['features'][256:512])
+
+    # Pickle the epoch and make sure that the data wasn't dumped
+    with open('epoch_test.pkl', 'wb') as f:
+        dill.dump(epoch, f, protocol=dill.HIGHEST_PROTOCOL)
+    assert os.path.getsize('epoch_test.pkl') < 1024 * 1024  # Less than 1MB
+
+    # Reload the epoch and make sure that the state was maintained
+    del epoch
+    with open('epoch_test.pkl', 'rb') as f:
+        epoch = dill.load(f)
+    features, targets = next(epoch)
+    assert numpy.all(features == mnist.data['features'][512:768])

--- a/tests/datasets/test_serialization.py
+++ b/tests/datasets/test_serialization.py
@@ -24,14 +24,15 @@ def test_in_memory():
     assert not os.path.exists(filename)
     with open(filename, 'wb') as f:
         dill.dump(epoch, f, protocol=dill.HIGHEST_PROTOCOL)
-    assert os.path.getsize(filename) < 1024 * 1024  # Less than 1MB
+    try:
+        assert os.path.getsize(filename) < 1024 * 1024  # Less than 1MB
 
-    # Reload the epoch and make sure that the state was maintained
-    del epoch
-    with open(filename, 'rb') as f:
-        epoch = dill.load(f)
-    features, targets = next(epoch)
-    assert numpy.all(features == mnist.data['features'][512:768])
-
-    # Clean up
-    os.remove(filename)
+        # Reload the epoch and make sure that the state was maintained
+        del epoch
+        with open(filename, 'rb') as f:
+            epoch = dill.load(f)
+        features, targets = next(epoch)
+        assert numpy.all(features == mnist.data['features'][512:768])
+    finally:
+        # Clean up
+        os.remove(filename)


### PR DESCRIPTION
Removed the generators used in schemes and replaced them with custom
iterators so that dill can serialize them. Also added a test that
serializes an MNIST data stream and deserializes it, checking whether
the state is maintained.

@rizar 