### PR TITLE
WIP: Training Data Monitoring

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -171,7 +171,8 @@ class GradientDescent(DifferentiableCostMinimizer):
         self.step_rule = step_rule if step_rule else SteepestDescent()
 
         self.total_gradient_norm = named_copy(
-            sum(g.norm(2) for g in self.gradients), "total_gradient_norm")
+            tensor.sqrt(sum((g ** 2).sum() for g in self.gradients)),
+            "total_gradient_norm")
 
     def initialize(self):
         all_updates = self.updates

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -184,7 +184,9 @@ class GradientDescent(DifferentiableCostMinimizer):
 
     def process_batch(self, batch):
         if not set(batch.keys()) == set([v.name for v in self.inputs]):
-            raise ValueError
+            raise ValueError("The names of the input variables of your"
+                             " computation graph must correspond to the"
+                             " data sources.")
         ordered_batch = [batch[v.name] for v in self.inputs]
         self._function(*ordered_batch)
 

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -7,6 +7,7 @@ from six import add_metaclass
 from theano import tensor
 
 from blocks.graph import ComputationGraph
+from blocks.utils import named_copy
 
 
 @add_metaclass(ABCMeta)
@@ -168,6 +169,9 @@ class GradientDescent(DifferentiableCostMinimizer):
             else dict(
                 zip(self.params, tensor.grad(self.cost, self.params))))
         self.step_rule = step_rule if step_rule else SteepestDescent()
+
+        self.total_gradient_norm = named_copy(
+            sum(g.norm(2) for g in self.gradients), "total_gradient_norm")
 
     def initialize(self):
         all_updates = self.updates

--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -103,6 +103,8 @@ class SimpleExtension(TrainingExtension):
 
     Parameters
     ----------
+    before_training : bool
+        If ``True``, :meth:`do` is invoked before training.
     before_first_epoch : bool
         If ``True``, :meth:`do` is invoked before the first epoch.
     after_every_epoch : bool
@@ -119,11 +121,14 @@ class SimpleExtension(TrainingExtension):
         batches are processed.
 
     """
-    def __init__(self, before_first_epoch=False, after_every_epoch=False,
-                 after_every_batch=False, after_training=False,
+    def __init__(self, before_training=False, before_first_epoch=False,
+                 after_every_epoch=False, after_every_batch=False,
+                 after_training=False,
                  after_n_epochs=None, after_n_batches=None, **kwargs):
         super(SimpleExtension, self).__init__(**kwargs)
         self._conditions = []
+        if before_training:
+            self.add_condition("before_training")
         if before_first_epoch:
             self.add_condition(
                 "before_epoch",

--- a/blocks/extensions/monitoring.py
+++ b/blocks/extensions/monitoring.py
@@ -1,10 +1,22 @@
 """Extensions for monitoring the training process."""
 from blocks.extensions import SimpleExtension
-from blocks.monitoring.evaluators import DatasetEvaluator
+from blocks.algorithms import DifferentiableCostMinimizer
+from blocks.monitoring.evaluators import AggregationBuffer, DatasetEvaluator
+
+PREFIX_SEPARATOR = '_'
+
+
+def _add_records(log, prefix, record_tuples):
+    """Helper function to add monitoring records to the log."""
+    for name, value in record_tuples:
+        prefixed_name = prefix + PREFIX_SEPARATOR + name
+        setattr(log.current_row, prefixed_name, value)
 
 
 class DataStreamMonitoring(SimpleExtension):
     """Monitors values of Theano expressions on a data stream.
+
+    By default monitoring is done before the first and after every epoch.
 
     Parameters
     ----------
@@ -32,6 +44,47 @@ class DataStreamMonitoring(SimpleExtension):
     def do(self, callback_name, *args):
         """Write the values of monitored expressions to the log."""
         value_dict = self._evaluator.evaluate(self.data_stream)
-        for name, value in value_dict.items():
-            prefixed_name = self.prefix + self.PREFIX_SEPARATOR + name
-            setattr(self.main_loop.log.current_row, prefixed_name, value)
+        _add_records(self.main_loop.log, self.prefix, value_dict.items())
+
+class TrainingDataMonitoring(SimpleExtension):
+    """Monitors values of Theano expressions on training batches.
+
+    Parameters
+    ----------
+    expressions : list of Theano variables
+        The expressions to monitor. The variable names are used as
+        expression names.
+    prefix : str
+        A prefix to add to expression names when adding records to the
+        log. An underscore will be used to separate the prefix.
+
+    Notes
+    -----
+
+        Requires the training algorithm to be an instance of
+        :class:`DifferentiableCostMinimizer`.
+
+    """
+    def __init__(self, expressions, prefix, **kwargs):
+        kwargs.setdefault("before_training", True)
+        super(TrainingDataMonitoring, self).__init__(**kwargs)
+        self._buffer = AggregationBuffer(expressions)
+        self._last_time_called = -1
+        self.prefix = prefix
+
+    def do(self, callback_name, *args):
+        """Write the values of monitored expressions to the log."""
+        if callback_name == self.before_training.__name__:
+            if not isinstance(self.main_loop.algorithm,
+                              DifferentiableCostMinimizer):
+                raise ValueError
+            self.main_loop.algorithm.add_updates(
+                self._buffer.accumulation_updates)
+            self._buffer.initialize_aggregators()
+        else:
+            if self.main_loop.status.iterations_done == self._last_time_called:
+                raise Exception("TrainingDataMonitoring.do should be invoked"
+                                " no more than once per iteration")
+            _add_records(self.main_loop.log, self.prefix,
+                            self._buffer.get_aggregated_values().items())
+            self._buffer.initialize_aggregators()

--- a/blocks/extensions/monitoring.py
+++ b/blocks/extensions/monitoring.py
@@ -46,6 +46,7 @@ class DataStreamMonitoring(SimpleExtension):
         value_dict = self._evaluator.evaluate(self.data_stream)
         _add_records(self.main_loop.log, self.prefix, value_dict.items())
 
+
 class TrainingDataMonitoring(SimpleExtension):
     """Monitors values of Theano expressions on training batches.
 
@@ -60,9 +61,8 @@ class TrainingDataMonitoring(SimpleExtension):
 
     Notes
     -----
-
-        Requires the training algorithm to be an instance of
-        :class:`DifferentiableCostMinimizer`.
+    Requires the training algorithm to be an instance of
+    :class:`DifferentiableCostMinimizer`.
 
     """
     def __init__(self, expressions, prefix, **kwargs):
@@ -86,5 +86,5 @@ class TrainingDataMonitoring(SimpleExtension):
                 raise Exception("TrainingDataMonitoring.do should be invoked"
                                 " no more than once per iteration")
             _add_records(self.main_loop.log, self.prefix,
-                            self._buffer.get_aggregated_values().items())
+                         self._buffer.get_aggregated_values().items())
             self._buffer.initialize_aggregators()

--- a/blocks/extensions/monitoring.py
+++ b/blocks/extensions/monitoring.py
@@ -68,7 +68,7 @@ class TrainingDataMonitoring(SimpleExtension):
     def __init__(self, expressions, prefix, **kwargs):
         kwargs.setdefault("before_training", True)
         super(TrainingDataMonitoring, self).__init__(**kwargs)
-        self._buffer = AggregationBuffer(expressions)
+        self._buffer = AggregationBuffer(expressions, use_take_last=True)
         self._last_time_called = -1
         self.prefix = prefix
 

--- a/blocks/monitoring/aggregation.py
+++ b/blocks/monitoring/aggregation.py
@@ -137,3 +137,16 @@ class _DataIndependent(AggregationScheme):
                           initialization_updates=[],
                           accumulation_updates=[],
                           readout_expression=self.variable)
+
+
+class TakeLast(AggregationScheme):
+    """Aggregation scheme which remembers only the last value."""
+    def __init__(self, variable):
+        self.variable = variable
+
+    def get_aggregator(self):
+        self.storage = shared_like(self.variable)
+        return Aggregator(aggregation_scheme=self,
+                          initialization_updates=[(self.storage, 0)],
+                          accumulation_updates=[(self.storage, self.variable)],
+                          readout_expression=self.storage)

--- a/blocks/monitoring/aggregation.py
+++ b/blocks/monitoring/aggregation.py
@@ -119,10 +119,11 @@ class Mean(AggregationScheme):
         return aggregator
 
 
-def mean(numerator, denominator):
+def mean(numerator, denominator=1.0):
     """Mean of quantity (numerator) over a number (denominator) values."""
     expression = numerator / denominator
     expression.tag.aggregation_scheme = Mean(numerator, denominator)
+    expression.name = numerator.name
     return expression
 
 

--- a/blocks/monitoring/aggregation.py
+++ b/blocks/monitoring/aggregation.py
@@ -147,6 +147,6 @@ class TakeLast(AggregationScheme):
     def get_aggregator(self):
         self.storage = shared_like(self.variable)
         return Aggregator(aggregation_scheme=self,
-                          initialization_updates=[(self.storage, 0)],
+                          initialization_updates=[(self.storage, 0.0)],
                           accumulation_updates=[(self.storage, self.variable)],
                           readout_expression=self.storage)

--- a/blocks/monitoring/evaluators.py
+++ b/blocks/monitoring/evaluators.py
@@ -10,14 +10,117 @@ from blocks.graph import ComputationGraph
 logger = logging.getLogger()
 
 
+class AggregationBuffer(object):
+    """Intermediate results of aggregating values of Theano expressions.
+
+    Incapsulates aggregators for a list of Theano expressions. Collects
+    the respective updates and provides initialization and readout
+    routines.
+
+    .. todo::
+
+        Write a better explanation what it is.
+
+    Parameters
+    ----------
+    expressions : list
+        If a list of Theano variables. The variable names are used as
+        expression names. All the variables names must be different.
+
+    Attributes
+    ----------
+    initialization_updates : list of tuples
+        Initialization updates of the aggregators.
+    accumulation_updates : list of tuples
+        Accumulation updates of the aggregators.
+    readout_expressions : dict
+        Maps an aggregated variable into a readout expression.
+    input : list of Theano variables
+        The list of inputs needed for accumulation.
+    input_names : list of str
+        The name of the inputs needed for accumulation.
+
+    """
+    def __init__(self, expressions):
+        self.expressions = expressions
+        self.expression_names = [v.name for v in self.expressions]
+        if len(self.expression_names) < len(self.expressions):
+            raise ValueError(
+                "Expression variables should have different names")
+        self.inputs = ComputationGraph(self.expressions).inputs
+        self.input_names = [v.name for v in self.inputs]
+
+        self._initialized = False
+        self._create_aggregators()
+        self._compile()
+
+    def _create_aggregators(self):
+        """Create aggregators and collect updates."""
+        self.initialization_updates = []
+        self.accumulation_updates = []
+        self.readout_expressions = OrderedDict()
+
+        for v in self.expressions:
+            logger.debug('Expression to evaluate: %s', v.name)
+            if not hasattr(v.tag, 'aggregation_scheme'):
+                if ComputationGraph([v]).inputs == []:
+                    logger.debug('Using _DataIndependent aggregation scheme'
+                                 ' for %s since it does not depend on'
+                                 ' the data', v.name)
+                    v.tag.aggregation_scheme = _DataIndependent(variable=v)
+                else:
+                    logger.debug('Using the default (average over minibatches)'
+                                 ' aggregation scheme for %s', v.name)
+                    v.tag.aggregation_scheme = Mean(v, 1.0)
+
+            aggregator = v.tag.aggregation_scheme.get_aggregator()
+            self.initialization_updates.extend(
+                aggregator.initialization_updates)
+            self.accumulation_updates.extend(aggregator.accumulation_updates)
+            self.readout_expressions[v.name] = aggregator.readout_expression
+
+    def _compile(self):
+        """Compiles Theano functions.
+
+        .. todo::
+
+            The current compilation method does not account for updates
+            attached to `ComputationGraph` elements. Compiling should
+            be out-sourced to `ComputationGraph` to deal with it.
+
+        """
+        if self.initialization_updates:
+            self._initialize_fun = theano.function(
+                [], [], updates=self.initialization_updates)
+        else:
+            self._initialize_fun = None
+
+        self._readout_fun = theano.function(
+            [], list(self.readout_expressions.values()))
+
+    def initialize_aggregators(self):
+        """Initialize the aggregators."""
+        self._initialized = True
+        if self._initialize_fun is not None:
+            self._initialize_fun()
+
+    def get_aggregated_values(self):
+        """Readout the aggregated values."""
+        if not self._initialized:
+            raise Exception("To readout you must first initialize, then"
+                            "process batches!")
+        ret_vals = self._readout_fun()
+        return dict(zip(self.expression_names, ret_vals))
+
+
 class DatasetEvaluator(object):
     """A DatasetEvaluator evaluates many Theano expressions on a dataset.
 
     The DatasetEvaluator provides a do-it-all method, :meth:`evaluate`,
     which computes values of ``expressions`` on a dataset.
 
-    Alternatively, methods :meth:`_initialize_computation`,
-    :meth:`_process_batch`, :meth:`_readout_expressions` can be used with a
+    Alternatively, methods :meth:`initialize_aggregators`,
+    :meth:`process_batch`, :meth:`get_aggregated_values` can be used with a
     custom loop over data.
 
     The values computed on subsets of the given dataset are aggregated
@@ -38,14 +141,7 @@ class DatasetEvaluator(object):
 
     """
     def __init__(self, expressions):
-        self.expressions = OrderedDict(
-            [(var.name, var) for var in expressions])
-        if len(self.expressions) < len(expressions):
-            raise ValueError(
-                "Expression variables should have different names")
-
-        self.inputs = ComputationGraph(
-            list(self.expressions.values())).inputs
+        self.buffer_ = AggregationBuffer(expressions)
         self._compile()
 
     def _compile(self):
@@ -58,63 +154,23 @@ class DatasetEvaluator(object):
             be out-sourced to `ComputationGraph` to deal with it.
 
         """
-        self._initialize_updates = []
-        self._accumulate_updates = []
-        self._readout = OrderedDict()
-
-        for k, v in self.expressions.items():
-            logger.debug('Expression to evaluate: %s', v.name)
-            if not hasattr(v.tag, 'aggregation_scheme'):
-                if ComputationGraph([v]).inputs == []:
-                    logger.debug('Using _DataIndependent aggregation scheme'
-                                 ' for %s since it does not depend on'
-                                 ' the data', k)
-                    v.tag.aggregation_scheme = _DataIndependent(variable=v)
-                else:
-                    logger.debug('Using the default (average over minibatches)'
-                                 ' aggregation scheme for %s', k)
-                    v.tag.aggregation_scheme = Mean(v, 1.0)
-
-            aggregator = v.tag.aggregation_scheme.get_aggregator()
-            self._initialize_updates.extend(aggregator.initialization_updates)
-            self._accumulate_updates.extend(aggregator.accumulation_updates)
-            self._readout[k] = aggregator.readout_expression
-
-        if self._initialize_updates:
-            self._initialize_fun = theano.function(
-                [], [], updates=self._initialize_updates)
-        else:
-            self._initialize_fun = None
-
-        self._initialized = False
-        self._input_names = [v.name for v in self.inputs]
-
-        if self._accumulate_updates:
+        if self.buffer_.accumulation_updates:
             self._accumulate_fun = theano.function(
-                self.inputs, [], updates=self._accumulate_updates)
+                self.buffer_.inputs, [],
+                updates=self.buffer_.accumulation_updates)
         else:
             self._accumulate_fun = None
 
-        self._readout_fun = theano.function([], list(self._readout.values()))
+    def initialize_aggregators(self):
+        self.buffer_.initialize_aggregators()
 
-    def _initialize_computation(self):
-        """Initialize the aggragators to process a dataset."""
-        self._initialized = True
-        if self._initialize_fun is not None:
-            self._initialize_fun()
-
-    def _process_batch(self, batch):
-        batch = dict_subset(batch, self._input_names)
+    def process_batch(self, batch):
+        batch = dict_subset(batch, self.buffer_.input_names)
         if self._accumulate_fun is not None:
             self._accumulate_fun(**batch)
 
-    def _readout_expressions(self):
-        if not self._initialized:
-            raise Exception("To readout you must first initialize, then"
-                            "process batches!")
-        self._initialized = False
-        ret_vals = self._readout_fun()
-        return dict(zip(self.expressions.keys(), ret_vals))
+    def get_aggregated_values(self):
+        return self.buffer_.get_aggregated_values()
 
     def evaluate(self, data_stream):
         """Compute the expressions over a data stream.
@@ -130,13 +186,14 @@ class DatasetEvaluator(object):
         provided dataset.
 
         """
-        self._initialize_computation()
+        self.initialize_aggregators()
 
         if self._accumulate_fun is not None:
             for batch in data_stream.get_epoch_iterator(as_dict=True):
-                self._process_batch(batch)
+                self.process_batch(batch)
         else:
-            logger.debug('Only constant monitors are used, will not'
-                         'iterate the over data!')
+            logger.debug(
+                'Only data independent expressions were given,'
+                'will not iterate the over data!')
 
-        return self._readout_expressions()
+        return self.get_aggregated_values()

--- a/blocks/monitoring/evaluators.py
+++ b/blocks/monitoring/evaluators.py
@@ -13,13 +13,10 @@ logger = logging.getLogger()
 class AggregationBuffer(object):
     """Intermediate results of aggregating values of Theano expressions.
 
-    Incapsulates aggregators for a list of Theano expressions. Collects
+    Encapsulates aggregators for a list of Theano expressions. Collects
     the respective updates and provides initialization and readout
     routines.
 
-    .. todo::
-
-        Write a better explanation what it is.
 
     Parameters
     ----------

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -13,7 +13,8 @@ from blocks.datasets.mnist import MNIST
 from blocks.datasets.schemes import SequentialScheme
 from blocks.extensions import FinishAfter, Printing
 from blocks.extensions.saveload import SerializeMainLoop
-from blocks.extensions.monitoring import DataStreamMonitoring
+from blocks.extensions.monitoring import (DataStreamMonitoring,
+                                          TrainingDataMonitoring)
 from blocks.main_loop import MainLoop
 
 
@@ -31,13 +32,14 @@ def main(save_to, num_epochs):
     mnist_train = MNIST("train")
     mnist_test = MNIST("test")
 
+    algorithm = GradientDescent(
+        cost=cost, step_rule=SteepestDescent(learning_rate=0.1))
     main_loop = MainLoop(
         mlp,
         DataStream(mnist_train,
                    iteration_scheme=SequentialScheme(
                        mnist_train.num_examples, 50)),
-        GradientDescent(cost=cost,
-                        step_rule=SteepestDescent(learning_rate=0.1)),
+        algorithm,
         extensions=[FinishAfter(after_n_epochs=num_epochs),
                     DataStreamMonitoring(
                         [cost, error_rate],
@@ -45,6 +47,11 @@ def main(save_to, num_epochs):
                                    iteration_scheme=SequentialScheme(
                                        mnist_test.num_examples, 500)),
                         prefix="test"),
+                    TrainingDataMonitoring(
+                        [cost, error_rate,
+                         algorithm.total_gradient_norm],
+                        prefix="train",
+                        after_every_epoch=True),
                     SerializeMainLoop(save_to),
                     Printing()])
     main_loop.run()

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -11,6 +11,7 @@ from blocks.initialization import IsotropicGaussian, Constant
 from blocks.datasets import DataStream
 from blocks.datasets.mnist import MNIST
 from blocks.datasets.schemes import SequentialScheme
+from blocks.monitoring import aggregation
 from blocks.extensions import FinishAfter, Printing
 from blocks.extensions.saveload import SerializeMainLoop
 from blocks.extensions.monitoring import (DataStreamMonitoring,
@@ -49,7 +50,7 @@ def main(save_to, num_epochs):
                         prefix="test"),
                     TrainingDataMonitoring(
                         [cost, error_rate,
-                         algorithm.total_gradient_norm],
+                         aggregation.mean(algorithm.total_gradient_norm)],
                         prefix="train",
                         after_every_epoch=True),
                     SerializeMainLoop(save_to),

--- a/tests/extensions/test_monitoring.py
+++ b/tests/extensions/test_monitoring.py
@@ -60,9 +60,6 @@ def test_training_data_monitoring():
         main_loop.log[n_batches].train2_cost,
         sum([main_loop.log[i].true_cost
              for i in range(n_batches)]) / n_batches)
-    # Here we legalize (temporarily) wierd behavior of data independent
-    # expressions measured at different stages depending on the aggregation
-    # scheme.
     assert_allclose(
         main_loop.log[n_batches].train2_W_sum,
         sum([main_loop.log[i].train1_W_sum

--- a/tests/extensions/test_monitoring.py
+++ b/tests/extensions/test_monitoring.py
@@ -66,4 +66,4 @@ def test_training_data_monitoring():
     assert_allclose(
         main_loop.log[n_batches].train2_W_sum,
         sum([main_loop.log[i].train1_W_sum
-             for i in range(1, n_batches)]) / n_batches)
+             for i in range(1, n_batches + 1)]) / n_batches)

--- a/tests/extensions/test_monitoring.py
+++ b/tests/extensions/test_monitoring.py
@@ -1,0 +1,58 @@
+import numpy
+import theano
+from theano import tensor
+from numpy.testing import assert_allclose
+
+from blocks.datasets import ContainerDataset
+from blocks.main_loop import MainLoop
+from blocks.extensions import TrainingExtension, FinishAfter
+from blocks.extensions.monitoring import TrainingDataMonitoring
+from blocks.algorithms import GradientDescent, SteepestDescent
+from blocks.utils import shared_floatx
+
+floatX = theano.config.floatX
+
+def test_training_data_monitoring():
+    weights = numpy.array([-1, 1], dtype=floatX)
+    features = [numpy.array(f, dtype=floatX)
+                for f in [[1, 2], [3, 4], [5, 6]]]
+    targets = [(weights * f).sum() for f in features]
+    n_batches = 3
+    dataset = ContainerDataset(dict(features=features, targets=targets))
+
+    x = tensor.vector('features')
+    y = tensor.scalar('targets')
+    W = shared_floatx([0, 0], name="W")
+    cost = ((x * W).sum() - y) ** 2
+    cost.name = 'cost'
+
+    class TrueCostExtension(TrainingExtension):
+
+        def before_batch(self, data):
+            self.main_loop.log.current_row.true_cost = (
+                ((W.get_value() * data["features"]).sum()
+                 - data["targets"]) ** 2)
+
+    main_loop = MainLoop(
+        model=None, data_stream=dataset.get_default_stream(),
+        algorithm=GradientDescent(cost=cost, params=[W],
+                                  step_rule=SteepestDescent(0.001)),
+        extensions=[
+            FinishAfter(after_n_epochs=1),
+            TrainingDataMonitoring([W, cost], "train1",
+                                    after_every_batch=True),
+            TrainingDataMonitoring([W, cost], "train2",
+                                    after_every_epoch=True),
+            TrueCostExtension()])
+
+    main_loop.run()
+
+    for i in range(n_batches):
+        # The ground truth is written to the log before the batch is
+        # processed, where as the extension writes after the batch is
+        # processed. This is why the iteration numbers differs here.
+        assert_allclose(main_loop.log[i].true_cost,
+                        main_loop.log[i + 1].train1_cost)
+    assert_allclose(
+        main_loop.log[n_batches].train2_cost,
+        sum([main_loop.log[i].true_cost for i in range(n_batches)]) / 3)

--- a/tests/extensions/test_monitoring.py
+++ b/tests/extensions/test_monitoring.py
@@ -12,6 +12,7 @@ from blocks.utils import shared_floatx
 
 floatX = theano.config.floatX
 
+
 def test_training_data_monitoring():
     weights = numpy.array([-1, 1], dtype=floatX)
     features = [numpy.array(f, dtype=floatX)
@@ -40,9 +41,9 @@ def test_training_data_monitoring():
         extensions=[
             FinishAfter(after_n_epochs=1),
             TrainingDataMonitoring([W, cost], "train1",
-                                    after_every_batch=True),
+                                   after_every_batch=True),
             TrainingDataMonitoring([W, cost], "train2",
-                                    after_every_epoch=True),
+                                   after_every_epoch=True),
             TrueCostExtension()])
 
     main_loop.run()

--- a/tests/extensions/test_monitoring.py
+++ b/tests/extensions/test_monitoring.py
@@ -4,11 +4,12 @@ from theano import tensor
 from numpy.testing import assert_allclose
 
 from blocks.datasets import ContainerDataset
-from blocks.main_loop import MainLoop
 from blocks.extensions import TrainingExtension, FinishAfter
 from blocks.extensions.monitoring import TrainingDataMonitoring
+from blocks.monitoring import aggregation
 from blocks.algorithms import GradientDescent, SteepestDescent
-from blocks.utils import shared_floatx
+from blocks.utils import shared_floatx, named_copy
+from blocks.main_loop import MainLoop
 
 floatX = theano.config.floatX
 
@@ -23,7 +24,8 @@ def test_training_data_monitoring():
 
     x = tensor.vector('features')
     y = tensor.scalar('targets')
-    W = shared_floatx([0, 0], name="W")
+    W = shared_floatx([0, 0], name='W')
+    W_sum = named_copy(W.sum(), 'W_sum')
     cost = ((x * W).sum() - y) ** 2
     cost.name = 'cost'
 
@@ -40,9 +42,9 @@ def test_training_data_monitoring():
                                   step_rule=SteepestDescent(0.001)),
         extensions=[
             FinishAfter(after_n_epochs=1),
-            TrainingDataMonitoring([W, cost], "train1",
+            TrainingDataMonitoring([W_sum, cost], "train1",
                                    after_every_batch=True),
-            TrainingDataMonitoring([W, cost], "train2",
+            TrainingDataMonitoring([aggregation.mean(W_sum), cost], "train2",
                                    after_every_epoch=True),
             TrueCostExtension()])
 
@@ -56,4 +58,12 @@ def test_training_data_monitoring():
                         main_loop.log[i + 1].train1_cost)
     assert_allclose(
         main_loop.log[n_batches].train2_cost,
-        sum([main_loop.log[i].true_cost for i in range(n_batches)]) / 3)
+        sum([main_loop.log[i].true_cost
+             for i in range(n_batches)]) / n_batches)
+    # Here we legalize (temporarily) wierd behavior of data independent
+    # expressions measured at different stages depending on the aggregation
+    # scheme.
+    assert_allclose(
+        main_loop.log[n_batches].train2_W_sum,
+        sum([main_loop.log[i].train1_W_sum
+             for i in range(1, n_batches)]) / n_batches)


### PR DESCRIPTION
In this pull request I implement what we typically call per-batch monitoring.

In order to do that the following changes are done:

* I separate a class `AggregationBuffer` from `DatasetEvaluator`. The new class is in fact simply a collection of aggregators and is agnostic to the way data is iterated.

* The `AggregationBuffer` is used in the `TrainingDataMonitoring` to do the job.

What I find quite cool about the way it is currently done is the user can control the period over which data is averaged by configuring the extension.

I plan to do a bit more before merging:

- [x] Add some more documentation to the extension.

- [x] Test the extension.