### PR TITLE
Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
         # Set up Python environment
         export PATH=$HOME/miniconda/bin:$PATH
         if [ ! `which conda` ]; then
+          rm -rf $HOME/miniconda
           wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
           chmod +x miniconda.sh
           ./miniconda.sh -b

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ env:
 before_install:
   - |
       if [ $TESTS ]; then
-        # Set up Python environment
+        # Setup Python environment with BLAS libraries
         export PATH=$HOME/miniconda/bin:$PATH
         if [ ! `which conda` ]; then
-          rm -rf $HOME/miniconda
           wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
           chmod +x miniconda.sh
+          rm -rf $HOME/miniconda
           ./miniconda.sh -b
         fi
         conda update -q --yes conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
         fi
         conda update -q --yes conda
         # Download MNIST for tests
-        if [ ! -d mnist ]; then
+        if find mnist -empty | read; then
           mkdir mnist
           cd mnist
           curl -O http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz \

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 cache:
   directories:
-    - miniconda
-    - mnist
+    - $HOME/miniconda
+    - $TRAVIS_BUILD_DIR/mnist
 branches:
   only:
     - master
@@ -19,7 +19,7 @@ before_install:
   - |
       if [ $TESTS ]; then
         # Set up Python environment
-        export PATH=/home/travis/miniconda/bin:$PATH
+        export PATH=$HOME/miniconda/bin:$PATH
         if [ ! `which conda` ]; then
           wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
           chmod +x miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 cache:
   directories:
     - miniconda
+    - pylearn2
+    - mnist
+    - .local
 branches:
   only:
     - master
@@ -50,7 +53,7 @@ install:
           python setup.py -q develop)
         else
           (cd pylearn2
-          git pull
+          git pull)
         fi
       fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ sudo: false
 cache:
   directories:
     - miniconda
-    - pylearn2
     - mnist
-    - .local
 branches:
   only:
     - master
@@ -30,13 +28,14 @@ before_install:
         conda update -q --yes conda
         # Download MNIST for tests
         if [ ! -d mnist ]; then
-          (mkdir mnist
+          mkdir mnist
           cd mnist
           curl -O http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz \
                -O http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz \
                -O http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz \
                -O http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
-          gunzip *-ubyte.gz)
+          gunzip *-ubyte.gz
+          cd -
         fi
         export BLOCKS_DATA_PATH=$PWD
       fi
@@ -47,14 +46,10 @@ install:
         conda install -q --yes python=$TRAVIS_PYTHON_VERSION nose numpy pip coverage six scipy
         pip install -q --no-deps git+git://github.com/Theano/Theano.git # Development version
         pip install -q nose2[coverage-plugin] coveralls
-        if [ ! -d pylearn2 ]; then
-          (git clone -q git://github.com/lisa-lab/pylearn2.git # Pylearn2 doesn't support pip
-          cd pylearn2
-          python setup.py -q develop)
-        else
-          (cd pylearn2
-          git pull)
-        fi
+        git clone -q git://github.com/lisa-lab/pylearn2.git # Pylearn2 doesn't support pip
+        cd pylearn2
+        python setup.py -q develop
+        cd -
       fi
   - |
       if [ $FORMAT ]; then
@@ -66,7 +61,7 @@ script:
       if [ $TESTS ]; then
         python setup.py -q install # Tests setup.py (also installs dill)
         # Must export environment variable so that the subprocess is aware of it
-        export THEANO_FLAGS=floatX=$TESTS,blas.ldflags='-lblas -lgfortran'
+        export THEANO_FLAGS=floatX=$TESTS
         # Running nose2 within coverage makes imports count towards coverage
         coverage run --source=blocks -m nose2.__main__ tests
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
 branches:
   only:
     - master
+    - travis_cache
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+sudo: false
+cache:
+  directories:
+    - miniconda
 branches:
   only:
     - master
@@ -12,21 +16,24 @@ env:
 before_install:
   - |
       if [ $TESTS ]; then
-        # Setup Python environment with BLAS libraries
-        sudo apt-get install -qq libatlas3gf-base libatlas-dev liblapack-dev gfortran
-        wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-        chmod +x miniconda.sh
-        ./miniconda.sh -b
+        # Set up Python environment
+        if [ ! `which conda` ]; then
+          wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+          chmod +x miniconda.sh
+          ./miniconda.sh -b
+        fi
         export PATH=/home/travis/miniconda/bin:$PATH
         conda update -q --yes conda
         # Download MNIST for tests
-        (mkdir mnist
-        cd mnist
-        curl -O http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz \
-             -O http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz \
-             -O http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz \
-             -O http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
-        gunzip *-ubyte.gz)
+        if [ ! -d mnist ]; then
+          (mkdir mnist
+          cd mnist
+          curl -O http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz \
+               -O http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz \
+               -O http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz \
+               -O http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
+          gunzip *-ubyte.gz)
+        fi
         export BLOCKS_DATA_PATH=$PWD
       fi
 install:
@@ -36,9 +43,14 @@ install:
         conda install -q --yes python=$TRAVIS_PYTHON_VERSION nose numpy pip coverage six scipy
         pip install -q --no-deps git+git://github.com/Theano/Theano.git # Development version
         pip install -q nose2[coverage-plugin] coveralls
-        (git clone -q git://github.com/lisa-lab/pylearn2.git # Pylearn2 doesn't support pip
-        cd pylearn2
-        python setup.py -q develop)
+        if [ ! -d pylearn2 ]; then
+          (git clone -q git://github.com/lisa-lab/pylearn2.git # Pylearn2 doesn't support pip
+          cd pylearn2
+          python setup.py -q develop)
+        else
+          (cd pylearn2
+          git pull
+        fi
       fi
   - |
       if [ $FORMAT ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 sudo: false
 cache:
   directories:
-    - $HOME/miniconda
     - $TRAVIS_BUILD_DIR/mnist
 branches:
   only:
     - master
-    - travis_cache
 language: python
 python:
   - "2.7"
@@ -19,15 +17,12 @@ before_install:
   - |
       if [ $TESTS ]; then
         # Setup Python environment with BLAS libraries
+        wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+        chmod +x miniconda.sh
+        ./miniconda.sh -b
         export PATH=$HOME/miniconda/bin:$PATH
-        if [ ! `which conda` ]; then
-          wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-          chmod +x miniconda.sh
-          rm -rf $HOME/miniconda
-          ./miniconda.sh -b
-        fi
         conda update -q --yes conda
-        # Download MNIST for tests
+        # Download MNIST for tests if not loaded from cache
         if find mnist -empty | read; then
           mkdir mnist
           cd mnist

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ before_install:
   - |
       if [ $TESTS ]; then
         # Set up Python environment
+        export PATH=/home/travis/miniconda/bin:$PATH
         if [ ! `which conda` ]; then
           wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
           chmod +x miniconda.sh
           ./miniconda.sh -b
         fi
-        export PATH=/home/travis/miniconda/bin:$PATH
         conda update -q --yes conda
         # Download MNIST for tests
         if [ ! -d mnist ]; then
@@ -43,7 +43,7 @@ install:
   # Install all Python dependencies
   - |
       if [ $TESTS ]; then
-        conda install -q --yes python=$TRAVIS_PYTHON_VERSION nose numpy pip coverage six scipy
+        conda install -q --yes python=$TRAVIS_PYTHON_VERSION mkl nose numpy pip coverage six scipy
         pip install -q --no-deps git+git://github.com/Theano/Theano.git # Development version
         pip install -q nose2[coverage-plugin] coveralls
         git clone -q git://github.com/lisa-lab/pylearn2.git # Pylearn2 doesn't support pip


### PR DESCRIPTION
Using the cache now to store MNIST in so that we don't overload their server. Theoretically we can also load all our Python modules from there, but in practice unpacking the cache is about as fast as installing binaries freshly, so let's stick to that for now. Using caching means no more `sudo` access, but we can use Anaconda's MKL library instead.

Miniconda caching code in case we ever need it:
```bash
export PATH=$HOME/miniconda/bin:$PATH
if [ ! `which conda` ]; then
  wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
  chmod +x miniconda.sh
  rm -rf $HOME/miniconda
  ./miniconda.sh -b
fi
```