### PR TITLE
Scripts

### DIFF
--- a/bin/blocks-continue
+++ b/bin/blocks-continue
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
-from argparse import ArgumentParser
+from argparse import ArgumentParser, FileType
 
 from blocks.scripts import continue_training
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = ArgumentParser("Continues your pickled main loop")
     parser.add_argument(
-        "path", help="A path to a file with a pickled main loop")
+        'infile', type=FileType('rb'),
+        help="File with a serialized main loop")
     parser.add_argument(
-        "--rec-limit", type=int, help="The recursion depth limit")
+        '--rec-limit', type=int, help="The recursion depth limit")
     args = parser.parse_args()
 
-    continue_training(args.path, args.rec_limit)
+    continue_training(args.infile, args.rec_limit)

--- a/bin/blocks-count-tokens
+++ b/bin/blocks-count-tokens
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import sys
+from argparse import ArgumentParser, FileType
+
+from blocks.scripts import count_tokens
+
+if __name__ == '__main__':
+    parser = ArgumentParser(
+        description="Count words or characters in text files.\n\n"
+                    "Reads lines from a text file(s) or standard input and "
+                    "counts the number of tokens. Outputs a list of token "
+                    "counts and tokens separated by a space. Can be used in "
+                    "pipelines e.g. to count lowercased tokens use: `tr "
+                    "[:upper:] [:lower:] | blocks-count-tokens`")
+    parser.add_argument(
+        'infile', type=FileType('r'), nargs='?', default=sys.stdin,
+        help="The file from which to read text")
+    parser.add_argument(
+        'outfile', type=FileType('w'), nargs='?', default=sys.stdout,
+        help="The file to which to write word counts")
+    parser.add_argument(
+        '-c', '--characters', action='store_true',
+        help="Count characters instead of words. To ignore spaces use "
+             "`tr -d ' '`")
+    args = parser.parse_args()
+
+    count_tokens(args.infile, args.outfile,
+                 'character' if args.characters else 'word')

--- a/bin/blocks-count-tokens
+++ b/bin/blocks-count-tokens
@@ -6,12 +6,12 @@ from blocks.scripts import count_tokens
 
 if __name__ == '__main__':
     parser = ArgumentParser(
-        description="Count words or characters in text files.\n\n"
-                    "Reads lines from a text file(s) or standard input and "
-                    "counts the number of tokens. Outputs a list of token "
-                    "counts and tokens separated by a space. Can be used in "
-                    "pipelines e.g. to count lowercased tokens use: `tr "
-                    "[:upper:] [:lower:] | blocks-count-tokens`")
+        description="Count words or characters in text files. Reads lines "
+                    "from a text file(s) or standard input and counts the "
+                    "number of tokens. Outputs a list of token counts and "
+                    "tokens separated by a space. Can be used in pipelines "
+                    "e.g. to count lowercased tokens use: `tr [:upper:] "
+                    "[:lower:] | blocks-count-tokens` ")
     parser.add_argument(
         'infile', type=FileType('r'), nargs='?', default=sys.stdin,
         help="The file from which to read text")

--- a/bin/blocks-create-vocabulary
+++ b/bin/blocks-create-vocabulary
@@ -6,16 +6,15 @@ from blocks.scripts import create_vocabulary
 
 if __name__ == '__main__':
     parser = ArgumentParser(
-        description="Construct a vocabulary from a list of token counts.\n\n"
-                    "The input is expected to be a file with a token count "
-                    "and a token on each line, separated by a space.\n\n"
-                    "The UNK, BOS and EOS token (if given) are numbered "
-                    "first, in that order. Then tokens are numbered in the "
-                    "order in which they were read. To number words "
-                    "alphabetically pipe through `sort -t ' ' -k 2`. If you "
-                    "want to limit your vocabulary, simply use e.g. `head -n "
-                    "1000`. If you need to sort your input, you can use `sort "
-                    "-n`")
+        description="Construct a vocabulary from a list of token counts. The "
+                    "input is expected to be a file with a token count and a "
+                    "token on each line, separated by a space. The UNK, BOS "
+                    "and EOS token (if given) are numbered first, in that "
+                    "order. Then tokens are numbered in the order in which "
+                    "they were read. To number words alphabetically pipe "
+                    "through `sort -t ' ' -k 2`. If you want to limit your "
+                    "vocabulary, simply use e.g. `head -n 1000`. If you need "
+                    "to sort your input, you can use `sort -n`")
     parser.add_argument(
         'infile', type=FileType('r'), nargs='?', default=sys.stdin,
         help="The file from which to read token counts.")

--- a/bin/blocks-create-vocabulary
+++ b/bin/blocks-create-vocabulary
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+import sys
+from argparse import ArgumentParser, FileType
+
+from blocks.scripts import create_vocabulary
+
+if __name__ == '__main__':
+    parser = ArgumentParser(
+        description="Construct a vocabulary from a list of token counts.\n\n"
+                    "The input is expected to be a file with a token count "
+                    "and a token on each line, separated by a space.\n\n"
+                    "Tokens are numbered according to the order in which they "
+                    "were read. The UNK, BOS and EOS tokens are numbered in "
+                    "that order.")
+    parser.add_argument(
+        'infile', type=FileType('r'), nargs='?', default=sys.stdin,
+        help="The file from which to read token counts.")
+    parser.add_argument(
+        'outfile', type=FileType('wb'),
+        help="The file to which to write the dictionary of word counts.")
+    parser.add_argument('--bos', type=str, nargs='?', const='<S>',
+                        help="Add the BOS token to the vocabulary.")
+    parser.add_argument('--eos', type=str, nargs='?', const='</S>',
+                        help="Add the EOS token to the vocabulary.")
+    parser.add_argument('--unk', type=str, nargs='?', default='<UNK>',
+                        help="The unknown token to use.")
+    parser.add_argument('--limit', type=int,
+                        help="Limit the number of words in the vocabulary. "
+                             "This includes the (optional) UNK, EOS and BOS "
+                             "tokens")
+    args = parser.parse_args()
+
+    create_vocabulary(args.infile, args.outfile, args.unk, args.eos, args.bos,
+                      args.limit)

--- a/bin/blocks-create-vocabulary
+++ b/bin/blocks-create-vocabulary
@@ -9,9 +9,10 @@ if __name__ == '__main__':
         description="Construct a vocabulary from a list of token counts.\n\n"
                     "The input is expected to be a file with a token count "
                     "and a token on each line, separated by a space.\n\n"
-                    "Tokens are numbered according to the order in which they "
-                    "were read. The UNK, BOS and EOS tokens are numbered in "
-                    "that order.")
+                    "The UNK, BOS and EOS token (if given) are numbered "
+                    "first, in that order. Then tokens are numbered i the "
+                    "order in which they were read. To number words "
+                    "alphabetically pipe through `sort -t ' ' -k 2`.")
     parser.add_argument(
         'infile', type=FileType('r'), nargs='?', default=sys.stdin,
         help="The file from which to read token counts.")

--- a/bin/blocks-create-vocabulary
+++ b/bin/blocks-create-vocabulary
@@ -10,9 +10,12 @@ if __name__ == '__main__':
                     "The input is expected to be a file with a token count "
                     "and a token on each line, separated by a space.\n\n"
                     "The UNK, BOS and EOS token (if given) are numbered "
-                    "first, in that order. Then tokens are numbered i the "
+                    "first, in that order. Then tokens are numbered in the "
                     "order in which they were read. To number words "
-                    "alphabetically pipe through `sort -t ' ' -k 2`.")
+                    "alphabetically pipe through `sort -t ' ' -k 2`. If you "
+                    "want to limit your vocabulary, simply use e.g. `head -n "
+                    "1000`. If you need to sort your input, you can use `sort "
+                    "-n`")
     parser.add_argument(
         'infile', type=FileType('r'), nargs='?', default=sys.stdin,
         help="The file from which to read token counts.")
@@ -25,11 +28,6 @@ if __name__ == '__main__':
                         help="Add the EOS token to the vocabulary.")
     parser.add_argument('--unk', type=str, nargs='?', default='<UNK>',
                         help="The unknown token to use.")
-    parser.add_argument('--limit', type=int,
-                        help="Limit the number of words in the vocabulary. "
-                             "This includes the (optional) UNK, EOS and BOS "
-                             "tokens")
     args = parser.parse_args()
 
-    create_vocabulary(args.infile, args.outfile, args.unk, args.eos, args.bos,
-                      args.limit)
+    create_vocabulary(args.infile, args.outfile, args.unk, args.eos, args.bos)

--- a/blocks/scripts/__init__.py
+++ b/blocks/scripts/__init__.py
@@ -34,10 +34,8 @@ def count_tokens(infile, outfile, token='word'):
             counter.update(line.split())
         else:
             counter.update(line.strip())
-    infile.close()
     for token, count in counter.most_common():
         outfile.write("{} {}\n".format(count, token))
-    outfile.close()
 
 
 def create_vocabulary(infile, outfile, unk='<UNK>', eos=None, bos=None):
@@ -51,6 +49,4 @@ def create_vocabulary(infile, outfile, unk='<UNK>', eos=None, bos=None):
         count, token = line.rstrip().split(maxsplit=1)
         vocabulary[token] = index
         index += 1
-    infile.close()
     dill.dump(vocabulary, outfile)
-    outfile.close()

--- a/blocks/scripts/__init__.py
+++ b/blocks/scripts/__init__.py
@@ -3,6 +3,12 @@ from collections import Counter
 
 import dill
 
+try:
+    BrokenPipeError
+except NameError:
+    # Note that IOError can strictly speaking be more things!
+    BrokenPipeError = IOError
+
 
 def continue_training(infile, rec_limit=None):
     if rec_limit:
@@ -34,8 +40,11 @@ def count_tokens(infile, outfile, token='word'):
             counter.update(line.split())
         else:
             counter.update(line.strip())
-    for token, count in counter.most_common():
-        outfile.write("{} {}\n".format(count, token))
+    try:
+        for token, count in counter.most_common():
+            outfile.write("{} {}\n".format(count, token))
+    except BrokenPipeError:
+        pass
 
 
 def create_vocabulary(infile, outfile, unk='<UNK>', eos=None, bos=None):

--- a/blocks/scripts/__init__.py
+++ b/blocks/scripts/__init__.py
@@ -40,8 +40,7 @@ def count_tokens(infile, outfile, token='word'):
     outfile.close()
 
 
-def create_vocabulary(infile, outfile, unk='<UNK>', eos=None, bos=None,
-                      limit=None):
+def create_vocabulary(infile, outfile, unk='<UNK>', eos=None, bos=None):
     vocabulary = {}
     index = 0
     for token in (unk, eos, bos):
@@ -49,8 +48,6 @@ def create_vocabulary(infile, outfile, unk='<UNK>', eos=None, bos=None,
             vocabulary[token] = index
             index += 1
     for line in infile:
-        if limit == index:
-            break
         count, token = line.rstrip().split(maxsplit=1)
         vocabulary[token] = index
         index += 1

--- a/blocks/scripts/__init__.py
+++ b/blocks/scripts/__init__.py
@@ -1,10 +1,59 @@
 import sys
+from collections import Counter
 
 import dill
 
 
-def continue_training(path, rec_limit=None):
+def continue_training(infile, rec_limit=None):
     if rec_limit:
         sys.setrecursionlimit(rec_limit)
-    main_loop = dill.load(open(path, "rb"))
-    main_loop.run()
+    mainfileloop = dill.load(infile)
+    mainfileloop.run()
+
+
+def count_tokens(infile, outfile, token='word'):
+    """Count words or characters.
+
+    The output will be a file with words ordered by their count.
+
+    Parameters
+    ----------
+    infile : file handle
+        The file handle to read data from.
+    outfile : file handle
+        The file handle to write the word counts to.
+    token : 'word' or 'character'
+        Whether to count words or individual characters
+
+    """
+    if token not in ('word', 'character'):
+        raise ValueError
+    counter = Counter()
+    for line in infile:
+        if token == 'word':
+            counter.update(line.split())
+        else:
+            counter.update(line.strip())
+    infile.close()
+    for token, count in counter.most_common():
+        outfile.write("{} {}\n".format(count, token))
+    outfile.close()
+
+
+def create_vocabulary(infile, outfile, unk='<UNK>', eos=None, bos=None,
+                      limit=None):
+    vocabulary = {}
+    index = 0
+    for token in (unk, eos, bos):
+        if token:
+            vocabulary[token] = index
+            index += 1
+    for line in infile:
+        if limit == index:
+            break
+        count, token = line.rstrip().split(maxsplit=1)
+        vocabulary[token] = index
+        index += 1
+    infile.close()
+    dill.dump(vocabulary, outfile)
+    outfile.close()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
     ],
     keywords='theano machine learning neural networks deep learning',
     packages=find_packages(exclude=['examples', 'docs', 'tests']),
-    scripts=['bin/blocks-continue'],
+    scripts=['bin/blocks-continue', 'bin/blocks-count-tokens',
+             'bin/blocks-create-vocabulary'],
     install_requires=['dill', 'numpy', 'theano', 'six'],
     extras_require={
         'test': ['nose', 'nose2'],


### PR DESCRIPTION
Some scripts to create word/character vocabularies out of text files.

I like the UNIX way of doing these kind of things, so I tried to make the scripts fit in. This means that if you e.g. want to lowercase words before counting, limit your vocabulary to a 1000, but number the words alphabetically, you can now do
```bash
cat *.en.txt | tr [:upper:] [:lower:] | blocks-count-tokens | head -n 1000 | sort -t ' ' -k 2 | blocks-create-vocabulary vocab.pkl
```