### PR TITLE
WIP: Live plotting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ script:
         # Must export environment variable so that the subprocess is aware of it
         export THEANO_FLAGS=floatX=$TESTS
         # Running nose2 within coverage makes imports count towards coverage
+        bokeh-server &> /dev/null &
         coverage run --source=blocks -m nose2.__main__ tests
       fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   # Install all Python dependencies
   - |
       if [ $TESTS ]; then
-        conda install -q --yes python=$TRAVIS_PYTHON_VERSION mkl nose numpy pip coverage six scipy
+        conda install -q --yes python=$TRAVIS_PYTHON_VERSION mkl bokeh nose numpy pip coverage six scipy
         pip install -q --no-deps git+git://github.com/Theano/Theano.git # Development version
         pip install -q nose2[coverage-plugin] coveralls
         git clone -q git://github.com/lisa-lab/pylearn2.git # Pylearn2 doesn't support pip

--- a/blocks/bricks/cost.py
+++ b/blocks/bricks/cost.py
@@ -62,7 +62,7 @@ class CategoricalCrossEntropy(Cost):
         return cost
 
 
-class MisclassficationRate(Cost):
+class MisclassificationRate(Cost):
     @application(outputs=["error_rate"])
     def apply(self, y, y_hat):
         return (tensor.sum(tensor.neq(y, y_hat.argmax(axis=1)))

--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -1,11 +1,6 @@
 from __future__ import print_function
 
 from abc import ABCMeta, abstractmethod
-try:
-    from bokeh.plotting import figure, output_server, show, cursession, push
-    bokeh_available = True
-except ImportError:
-    bokeh_available = False
 
 from six import add_metaclass
 
@@ -305,40 +300,3 @@ class Printing(SimpleExtension):
                 log.status.iterations_done))
             self._print_attributes(log.current_row)
         print()
-
-
-class Plot(SimpleExtension):
-    tableau20 = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
-                 '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf']
-
-    def __init__(self, document, monitors=None, open_browser=True, **kwargs):
-        if not bokeh_available:
-            raise ImportError
-        self.plots = {}
-        output_server(document)
-
-        self.p = figure(title=document)
-        if open_browser:
-            show(self.p)
-
-        kwargs.setdefault('after_every_epoch', True)
-        kwargs.setdefault("before_first_epoch", True)
-        super(Plot, self).__init__(**kwargs)
-
-    def do(self, which_callback, *args):
-        log = self.main_loop.log
-        iteration = log.status.iterations_done
-        i = 0
-        for key, value in log.current_row:
-            if key not in self.plots:
-                self.p.line([iteration], [value], legend=key,
-                            x_axis_label='iterations', y_axis_label='value',
-                            name=key, line_color=self.tableau20[i])
-                i += 1
-                renderer = self.p.select(dict(name=key))
-                self.plots[key] = renderer[0].data_source
-            else:
-                self.plots[key].data['x'].append(iteration)
-                self.plots[key].data['y'].append(value)
-                cursession().store_objects(self.plots[key])
-        push()

--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 from abc import ABCMeta, abstractmethod
 try:
-    from bokeh.plotting import figure, output_server, show, cursession
+    from bokeh.plotting import figure, output_server, show, cursession, push
     bokeh_available = True
 except ImportError:
     bokeh_available = False
@@ -308,33 +308,37 @@ class Printing(SimpleExtension):
 
 
 class Plot(SimpleExtension):
-    def __init__(self, document, **kwargs):
+    tableau20 = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
+                 '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf']
+
+    def __init__(self, document, monitors=None, open_browser=True, **kwargs):
         if not bokeh_available:
             raise ImportError
         self.plots = {}
         output_server(document)
 
         self.p = figure(title=document)
+        if open_browser:
+            show(self.p)
 
         kwargs.setdefault('after_every_epoch', True)
+        kwargs.setdefault("before_first_epoch", True)
         super(Plot, self).__init__(**kwargs)
 
     def do(self, which_callback, *args):
         log = self.main_loop.log
         iteration = log.status.iterations_done
-        new = False
+        i = 0
         for key, value in log.current_row:
             if key not in self.plots:
                 self.p.line([iteration], [value], legend=key,
                             x_axis_label='iterations', y_axis_label='value',
-                            name=key)
+                            name=key, line_color=self.tableau20[i])
+                i += 1
                 renderer = self.p.select(dict(name=key))
                 self.plots[key] = renderer[0].data_source
-                new = True
             else:
                 self.plots[key].data['x'].append(iteration)
                 self.plots[key].data['y'].append(value)
                 cursession().store_objects(self.plots[key])
-        if new:
-            show(self.p)
-            new = False
+        push()

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -56,7 +56,7 @@ class Plot(SimpleExtension):
     document : str
         The name of the Bokeh document. Use a different name for each
         experiment if you are storing your plots.
-    monitors : list of lists of strings
+    channels : list of lists of strings
         The names of the monitor channels that you want to plot. The
         channels in a single sublist will be plotted together in a single
         figure, so use e.g. ``[['test_cost', 'train_cost'],
@@ -86,7 +86,7 @@ class Plot(SimpleExtension):
     colors = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
               '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf']
 
-    def __init__(self, document, monitors, open_browser=False,
+    def __init__(self, document, channels, open_browser=False,
                  start_server=False, **kwargs):
         if not bokeh_available:
             raise ImportError
@@ -98,10 +98,10 @@ class Plot(SimpleExtension):
         # Create figures for each group of channels
         self.p = []
         self.p_indices = {}
-        for i, monitor_set in enumerate(monitors):
+        for i, channel_set in enumerate(channels):
             self.p.append(figure(title='{} #{}'.format(document, i + 1)))
-            for monitor in monitor_set:
-                self.p_indices[monitor] = i
+            for channel in channel_set:
+                self.p_indices[channel] = i
         if open_browser:
             show()
 

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -1,0 +1,44 @@
+try:
+    from bokeh.plotting import figure, output_server, show, cursession, push
+    bokeh_available = True
+except ImportError:
+    bokeh_available = False
+
+from block.extensions import SimpleExtension
+
+
+class Plot(SimpleExtension):
+    tableau20 = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
+                 '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf']
+
+    def __init__(self, document, monitors=None, open_browser=True, **kwargs):
+        if not bokeh_available:
+            raise ImportError
+        self.plots = {}
+        output_server(document)
+
+        self.p = figure(title=document)
+        if open_browser:
+            show(self.p)
+
+        kwargs.setdefault('after_every_epoch', True)
+        kwargs.setdefault("before_first_epoch", True)
+        super(Plot, self).__init__(**kwargs)
+
+    def do(self, which_callback, *args):
+        log = self.main_loop.log
+        iteration = log.status.iterations_done
+        i = 0
+        for key, value in log.current_row:
+            if key not in self.plots:
+                self.p.line([iteration], [value], legend=key,
+                            x_axis_label='iterations', y_axis_label='value',
+                            name=key, line_color=self.tableau20[i])
+                i += 1
+                renderer = self.p.select(dict(name=key))
+                self.plots[key] = renderer[0].data_source
+            else:
+                self.plots[key].data['x'].append(iteration)
+                self.plots[key].data['y'].append(value)
+                cursession().store_objects(self.plots[key])
+        push()

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -1,25 +1,82 @@
+import logging
+import signal
+import time
+from subprocess import Popen, PIPE
+
 try:
     from bokeh.plotting import figure, output_server, show, cursession, push
     bokeh_available = True
 except ImportError:
     bokeh_available = False
 
-from block.extensions import SimpleExtension
+from blocks.extensions import SimpleExtension
+
+logger = logging.getLogger(__name__)
 
 
 class Plot(SimpleExtension):
-    tableau20 = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
-                 '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf']
+    """Plot values from the log using the Bokeh plotting server.
 
-    def __init__(self, document, monitors=None, open_browser=True, **kwargs):
+    .. warning::
+
+       By default this extension will try to start the Bokeh plotting
+       server. To make sure that you do not lose your plots the moment
+       training completes, this extension will not shut down the plotting
+       server. You must do so manually (the PID will be shown in the logs).
+
+    Parameters
+    ----------
+    document : str
+        The name of the Bokeh document. Use a different name for each
+        experiment if you are storing your plots.
+    monitors : list of lists of strings
+        The names of the monitor channels that you want to plot. The
+        channels in a single sublist will be plotted together in a single
+        figure, so use e.g. ``[['test_cost', 'train_cost'],
+        ['weight_norms']]`` to plot a single figure with the training and
+        test cost, and a second figure for the weight norms.
+    open_browser : bool, optional
+        Whether to try and open the plotting server in a browser window.
+        Defaults to ``True``. Should probably be set to ``False`` when
+        running experiments non-locally (e.g. on a cluster or through SSH).
+    start_server : bool, optional
+        Whether to try and start the Bokeh plotting server. Defaults to
+        ``True``. The server started is not persistent i.e. after shutting
+        it down you will lose your plots. If you want to store your plots,
+        start the server manually using the ``bokeh-server`` command and
+        set this argument to ``False``. Also see the warning above.
+
+    Notes
+    -----
+    On deserialization (i.e. when resuming training), this extension will
+    attempt to start the server as well (if ``start_server`` was ``True``)
+    so that it can continue sending information to the plotting server.
+    However, if you didn't shut down the plotting server before resuming
+    training, it will most likely crash.
+
+    """
+    # Tableau 10 colors
+    colors = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
+              '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf']
+
+    def __init__(self, document, monitors, open_browser=True,
+                 start_server=True, **kwargs):
         if not bokeh_available:
             raise ImportError
         self.plots = {}
+        self.start_server = start_server
+        self._startserver()
         output_server(document)
 
-        self.p = figure(title=document)
+        # Create figures for each group of channels
+        self.p = []
+        self.p_indices = {}
+        for i, monitor_set in enumerate(monitors):
+            self.p.append(figure(title='{} #{}'.format(document, i + 1)))
+            for monitor in monitor_set:
+                self.p_indices[monitor] = i
         if open_browser:
-            show(self.p)
+            show()
 
         kwargs.setdefault('after_every_epoch', True)
         kwargs.setdefault("before_first_epoch", True)
@@ -30,15 +87,42 @@ class Plot(SimpleExtension):
         iteration = log.status.iterations_done
         i = 0
         for key, value in log.current_row:
-            if key not in self.plots:
-                self.p.line([iteration], [value], legend=key,
-                            x_axis_label='iterations', y_axis_label='value',
-                            name=key, line_color=self.tableau20[i])
-                i += 1
-                renderer = self.p.select(dict(name=key))
-                self.plots[key] = renderer[0].data_source
-            else:
-                self.plots[key].data['x'].append(iteration)
-                self.plots[key].data['y'].append(value)
-                cursession().store_objects(self.plots[key])
+            if key in self.p_indices:
+                if key not in self.plots:
+                    fig = self.p[self.p_indices[key]]
+                    fig.line([iteration], [value], legend=key,
+                             x_axis_label='iterations',
+                             y_axis_label='value', name=key,
+                             line_color=self.colors[i % len(self.colors)])
+                    i += 1
+                    renderer = fig.select(dict(name=key))
+                    self.plots[key] = renderer[0].data_source
+                else:
+                    self.plots[key].data['x'].append(iteration)
+                    self.plots[key].data['y'].append(value)
+                    cursession().store_objects(self.plots[key])
         push()
+
+    def _startserver(self):
+        if self.start_server:
+            def preexec_fn():
+                """Prevents the server from dying on training interrupt."""
+                signal.signal(signal.SIGINT, signal.SIG_IGN)
+            # Only memory works with subprocess, need to wait for it to start
+            logger.info('Starting plotting server on localhost:5006')
+            self.sub = Popen('bokeh-server --ip 0.0.0.0 '
+                             '--backend memory'.split(),
+                             stdout=PIPE, stderr=PIPE, preexec_fn=preexec_fn)
+            time.sleep(2)
+            logger.info('Plotting server PID: {}'.format(self.sub.pid))
+        else:
+            self.sub = None
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state['sub']
+        return state
+
+    def __setstate(self, state):
+        self.__dict__.update(state)
+        self._startserver()

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -15,14 +15,41 @@ logger = logging.getLogger(__name__)
 
 
 class Plot(SimpleExtension):
-    """Plot values from the log using the Bokeh plotting server.
+    """Live plotting of monitoring channels.
+
+    This extension uses Bokeh server to give you access to live updated
+    plots of the monitoring values you specify. The best thing to do is to
+    start the Bokeh server manually by running the command:
+
+    .. code-block:: bash
+
+       bokeh-server
+
+    This should make your plots accesible at ``http://localhost:5006``. If
+    you want to look at your plots over the internet or a network, use
+
+    .. code-block:: bash
+
+       bokeh-server --ip 0.0.0.0
+
+    By default the Bokeh server stores your plots, so you won't lose them
+    if you stop and restart the server.
+
+    Alternatively, you can set the ``start_server`` argument of this
+    extension to ``True``, to automatically start a server when training
+    starts. However, in that case your plots will be deleted when you shut
+    down the plotting server!
 
     .. warning::
 
-       By default this extension will try to start the Bokeh plotting
-       server. To make sure that you do not lose your plots the moment
-       training completes, this extension will not shut down the plotting
-       server. You must do so manually (the PID will be shown in the logs).
+       When starting the server automatically using the ``start_server``
+       argument, the extension won't attempt to shut down the server at the
+       end of training (to make sure that you do not lose your plots the
+       moment training completes). You have to shut it down manually (the
+       PID will be shown in the logs). If you don't do this, this extension
+       will crash when you try and train another model with
+       ``start_server`` set to ``True``, because it can't run two servers
+       at the same time.
 
     Parameters
     ----------
@@ -41,10 +68,10 @@ class Plot(SimpleExtension):
         running experiments non-locally (e.g. on a cluster or through SSH).
     start_server : bool, optional
         Whether to try and start the Bokeh plotting server. Defaults to
-        ``True``. The server started is not persistent i.e. after shutting
+        ``False``. The server started is not persistent i.e. after shutting
         it down you will lose your plots. If you want to store your plots,
-        start the server manually using the ``bokeh-server`` command and
-        set this argument to ``False``. Also see the warning above.
+        start the server manually using the ``bokeh-server`` command. Also
+        see the warning above.
 
     Notes
     -----
@@ -59,8 +86,8 @@ class Plot(SimpleExtension):
     colors = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
               '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf']
 
-    def __init__(self, document, monitors, open_browser=True,
-                 start_server=True, **kwargs):
+    def __init__(self, document, monitors, open_browser=False,
+                 start_server=False, **kwargs):
         if not bokeh_available:
             raise ImportError
         self.plots = {}

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -147,7 +147,7 @@ class Plot(SimpleExtension):
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        del state['sub']
+        state.sub = None
         return state
 
     def __setstate(self, state):

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -147,7 +147,7 @@ class Plot(SimpleExtension):
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        state.sub = None
+        state['sub'] = None
         return state
 
     def __setstate(self, state):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,7 +76,7 @@ Quickstart
    >>> from theano import tensor
    >>> from blocks.algorithms import GradientDescent, SteepestDescent
    >>> from blocks.bricks import MLP, Tanh, Softmax
-   >>> from blocks.bricks.cost import CategoricalCrossEntropy, MisclassficationRate
+   >>> from blocks.bricks.cost import CategoricalCrossEntropy, MisclassificationRate
    >>> from blocks.initialization import IsotropicGaussian, Constant
    >>> from blocks.datasets import DataStream
    >>> from blocks.datasets.mnist import MNIST
@@ -97,7 +97,7 @@ Calculate your loss function.
     >>> y = tensor.lmatrix('targets')
     >>> y_hat = mlp.apply(x)
     >>> cost = CategoricalCrossEntropy().apply(y.flatten(), y_hat)
-    >>> error_rate = MisclassficationRate().apply(y.flatten(), y_hat)
+    >>> error_rate = MisclassificationRate().apply(y.flatten(), y_hat)
 
 Load your training data.
 

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -7,7 +7,7 @@ from theano import tensor
 
 from blocks.algorithms import GradientDescent, SteepestDescent
 from blocks.bricks import MLP, Tanh, Softmax, WEIGHTS
-from blocks.bricks.cost import CategoricalCrossEntropy, MisclassficationRate
+from blocks.bricks.cost import CategoricalCrossEntropy, MisclassificationRate
 from blocks.initialization import IsotropicGaussian, Constant
 from blocks.datasets import DataStream
 from blocks.datasets.mnist import MNIST
@@ -19,7 +19,7 @@ from blocks.extensions import FinishAfter, Timing, Printing
 from blocks.extensions.saveload import SerializeMainLoop
 from blocks.extensions.monitoring import (DataStreamMonitoring,
                                           TrainingDataMonitoring)
-from blocks.extensions import Plot
+from blocks.extensions.plot import Plot
 from blocks.main_loop import MainLoop
 
 
@@ -32,7 +32,7 @@ def main(save_to, num_epochs):
     y = tensor.lmatrix('targets')
     probs = mlp.apply(x)
     cost = CategoricalCrossEntropy().apply(y.flatten(), probs)
-    error_rate = MisclassficationRate().apply(y.flatten(), probs)
+    error_rate = MisclassificationRate().apply(y.flatten(), probs)
 
     cg = ComputationGraph([cost])
     W1, W2 = VariableFilter(roles=[WEIGHTS])(cg.variables)
@@ -64,7 +64,12 @@ def main(save_to, num_epochs):
                         prefix="train",
                         after_every_epoch=True),
                     SerializeMainLoop(save_to),
-                    Plot('MNIST example'),
+                    Plot(
+                        'MNIST example',
+                        monitors=[
+                            ['test_final_cost',
+                             'test_misclassificationrate_apply_error_rate'],
+                            ['train_total_gradient_norm']]),
                     Printing()])
     main_loop.run()
 

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -19,6 +19,7 @@ from blocks.extensions import FinishAfter, Printing
 from blocks.extensions.saveload import SerializeMainLoop
 from blocks.extensions.monitoring import (DataStreamMonitoring,
                                           TrainingDataMonitoring)
+from blocks.extensions import Plot
 from blocks.main_loop import MainLoop
 
 
@@ -62,6 +63,7 @@ def main(save_to, num_epochs):
                         prefix="train",
                         after_every_epoch=True),
                     SerializeMainLoop(save_to),
+                    Plot('MNIST example'),
                     Printing()])
     main_loop.run()
 

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -66,7 +66,7 @@ def main(save_to, num_epochs):
                     SerializeMainLoop(save_to),
                     Plot(
                         'MNIST example',
-                        monitors=[
+                        channels=[
                             ['test_final_cost',
                              'test_misclassificationrate_apply_error_rate'],
                             ['train_total_gradient_norm']]),

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     install_requires=['dill', 'numpy', 'theano', 'six'],
     extras_require={
         'test': ['nose', 'nose2'],
+        'plot': ['bokeh']
     },
     zip_safe=False
 )


### PR DESCRIPTION
I very much like the idea of live plotting, as recently [implemented in Pylearn2](https://github.com/lisa-lab/pylearn2/blob/master/pylearn2/train_extensions/live_monitoring.py) by Dustin. However, I don't want to write 400 lines of code and use a messaging framework to do it...

So I tried some other solutions. Yesterday I set up InfluxDB and Grafana, which turned out to be not that straightforward, complete overkill, and actually not very good to work with (because it assumes time stamped data). I looked into Bokeh this morning (it's a library I've been following for a while) which seems to work quite nicely.

As this PR stands, the user would have to type `bokeh-server` to start the plotting server, and can then start training with `Plot('Experiment title')` as an extension. You can then automatically watch live updating plots of all your monitors!

![screen shot 2015-01-28 at 9 15 54 am](https://cloud.githubusercontent.com/assets/2299595/5939120/12e5e7b4-a6cf-11e4-88dd-d2dcc9b1f36e.png)

It works quite nicely as a proof of concept, but it's obviously a bit rough around the edges and hence WIP:

- [x] All lines have the same color right now
- [x] The user needs to be able to control which monitors get plotted
- [x] The user should be able to decide which plots go in the same figure, and which go in separate figures
- [ ] The x-axis should start at 0
- [x] Currently it's quite slow; it takes a second or two for the plot to update each time, which isn't a problem for longer epochs, but if your epochs are less than a second long (like in the MNIST example) it kind of defeats the purpose
- [x] Start Bokeh server automagically if not started already