### PR TITLE
No more global seed

### DIFF
--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -36,9 +36,24 @@ class Random(Brick):
         A ``MRG_RandomStreams`` instance.
 
     """
-    def __init__(self, theano_rng=None, **kwargs):
+    seed_rng = numpy.random.RandomState(config.default_seed)
+
+    def __init__(self, theano_seed=None, **kwargs):
         super(Random, self).__init__(**kwargs)
-        self.theano_rng = theano_rng
+        self.theano_seed = theano_seed
+
+    @property
+    def theano_seed(self):
+        if getattr(self, '_theano_seed', None) is not None:
+            return self._theano_seed
+        else:
+            self._theano_seed = self.seed_rng.randint(
+                numpy.iinfo(numpy.int32).max)
+            return self._theano_seed
+
+    @theano_seed.setter
+    def theano_seed(self, value):
+        self._theano_seed = value
 
     @property
     def theano_rng(self):
@@ -50,8 +65,7 @@ class Random(Brick):
         if getattr(self, '_theano_rng', None) is not None:
             return self._theano_rng
         else:
-            return MRG_RandomStreams(
-                config.default_seed)
+            return MRG_RandomStreams(self.theano_seed)
 
     @theano_rng.setter
     def theano_rng(self, theano_rng):
@@ -93,7 +107,7 @@ class Initializable(Brick):
 
     """
     has_biases = True
-    global_rng = numpy.random.RandomState(config.default_seed)
+    seed_rng = numpy.random.RandomState(config.default_seed)
 
     @lazy
     def __init__(self, weights_init, biases_init=None, use_bias=True,
@@ -112,7 +126,7 @@ class Initializable(Brick):
         if getattr(self, '_seed', None) is not None:
             return self._seed
         else:
-            self._seed = self.global_rng.randint(
+            self._seed = self.seed_rng.randint(
                 numpy.iinfo(numpy.int32).max)
             return self._seed
 

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -93,10 +93,11 @@ class Initializable(Brick):
 
     """
     has_biases = True
+    global_rng = numpy.random.RandomState(config.default_seed)
 
     @lazy
-    def __init__(self, weights_init, biases_init=None, use_bias=True, rng=None,
-                 **kwargs):
+    def __init__(self, weights_init, biases_init=None, use_bias=True,
+                 seed=None, **kwargs):
         super(Initializable, self).__init__(**kwargs)
         self.weights_init = weights_init
         if self.has_biases:
@@ -104,14 +105,27 @@ class Initializable(Brick):
         elif biases_init is not None or not use_bias:
             raise ValueError("This brick does not support biases config")
         self.use_bias = use_bias
-        self.rng = rng
+        self.seed = seed
+
+    @property
+    def seed(self):
+        if getattr(self, '_seed', None) is not None:
+            return self._seed
+        else:
+            self._seed = self.global_rng.randint(
+                numpy.iinfo(numpy.int32).max)
+            return self._seed
+
+    @seed.setter
+    def seed(self, value):
+        self._seed = value
 
     @property
     def rng(self):
         if getattr(self, '_rng', None) is not None:
             return self._rng
         else:
-            return numpy.random.RandomState(config.default_seed)
+            return numpy.random.RandomState(self.seed)
 
     @rng.setter
     def rng(self, rng):

--- a/blocks/graph.py
+++ b/blocks/graph.py
@@ -9,6 +9,7 @@ from theano.gof import graph
 from theano.gof.sched import make_dependence_cmp, sort_apply_nodes
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 
+from blocks import config
 from blocks.utils import (is_graph_input, is_shared_variable, dict_union,
                           shared_like)
 
@@ -300,7 +301,7 @@ class Annotation(object):
         self.auxiliary_variables.append(expression)
 
 
-def apply_noise(graph, variables, level, rng=None):
+def apply_noise(graph, variables, level, seed=None):
     """Add Gaussian noise to certain variable of a computation graph.
 
     Parameters
@@ -316,8 +317,9 @@ def apply_noise(graph, variables, level, rng=None):
         used.
 
     """
-    if not rng:
-        rng = MRG_RandomStreams(1)
+    if not seed:
+        seed = config.default_seed
+    rng = MRG_RandomStreams(seed)
     replace = {}
     for variable in variables:
         replace[variable] = (variable +

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -136,7 +136,7 @@ will want to initialize these parameters by sampling them from a particular
 probability distribution. Bricks can do this for you.
 
 >>> from blocks.initialization import IsotropicGaussian, Constant
->>> input_to_hidden.weights_init = hidden_to_output.weights_init = IsotropicGaussian(std=0.01)
+>>> input_to_hidden.weights_init = hidden_to_output.weights_init = IsotropicGaussian(0.01)
 >>> input_to_hidden.biases_init = hidden_to_output.biases_init = Constant(0)
 >>> input_to_hidden.initialize()
 >>> hidden_to_output.initialize()

--- a/examples/sqrt.py
+++ b/examples/sqrt.py
@@ -43,7 +43,7 @@ def get_data_stream(iterable):
 def main(save_to, num_batches, continue_=False):
     mlp = MLP([Tanh(), Identity()], [1, 10, 1],
               weights_init=IsotropicGaussian(0.01),
-              biases_init=Constant(0))
+              biases_init=Constant(0), seed=1)
     mlp.initialize()
     x = tensor.vector('numbers')
     y = tensor.vector('roots')

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -4,7 +4,6 @@ import theano
 from numpy.testing import assert_allclose, assert_raises
 from theano import tensor
 
-from blocks import config
 from blocks.bricks import Identity, Linear, Maxout, LinearMaxout, MLP, Tanh
 from blocks.bricks.base import Application, application, Brick, lazy
 from blocks.filter import get_application_call
@@ -272,10 +271,11 @@ def test_apply():
 def test_rng():
     linear = Linear()
     assert isinstance(linear.rng, numpy.random.RandomState)
-    assert linear.rng.rand() == \
-        numpy.random.RandomState(config.default_seed).rand()
-    linear = Linear(rng=numpy.random.RandomState(1))
+    linear = Linear(seed=1)
     assert linear.rng.rand() == numpy.random.RandomState(1).rand()
+    linear = Linear()
+    linear2 = Linear()
+    assert linear.seed != linear2.seed
 
 
 def test_linear():

--- a/tests/bricks/test_recurrent.py
+++ b/tests/bricks/test_recurrent.py
@@ -67,7 +67,7 @@ class TestGatedRecurrent(unittest.TestCase):
         self.reset_only = GatedRecurrent(
             dim=3, weights_init=IsotropicGaussian(),
             activation=Tanh(), gate_activation=Tanh(),
-            use_update_gate=False, rng=numpy.random.RandomState(1))
+            use_update_gate=False, seed=1)
         self.reset_only.initialize()
 
     def test_one_step(self):
@@ -125,9 +125,10 @@ class TestBidirectional(unittest.TestCase):
     def setUp(self):
         self.bidir = Bidirectional(weights_init=Orthogonal(),
                                    prototype=Recurrent(
-                                       dim=3, activation=Tanh()))
+                                       dim=3, activation=Tanh()),
+                                   seed=1)
         self.simple = Recurrent(dim=3, weights_init=Orthogonal(),
-                                activation=Tanh())
+                                activation=Tanh(), seed=1)
         self.bidir.initialize()
         self.simple.initialize()
         self.x_val = 0.1 * numpy.asarray(

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -60,4 +60,4 @@ def test_apply_noise():
     noised_cg = apply_noise(cg, [y], 1, 1)
     assert_allclose(
         noised_cg.outputs[0].eval({x: 1., y: 1.}),
-        2 + MRG_RandomStreams(1).normal(y.shape).eval({y: 1.}))
+        2 + MRG_RandomStreams(1).normal(tuple()).eval())

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,7 +2,7 @@ import numpy
 import theano
 from numpy.testing import assert_allclose
 from theano import tensor
-from theano.tensor.shared_randomstreams import RandomStreams
+from theano.sandbox.rng_mrg import MRG_RandomStreams
 
 from blocks.bricks.base import Brick
 from blocks.graph import apply_noise, ComputationGraph
@@ -57,7 +57,7 @@ def test_apply_noise():
     z = x + y
 
     cg = ComputationGraph([z])
-    rng = RandomStreams(1)
-    noised_cg = apply_noise(cg, [y], 1, rng)
-    assert_allclose(noised_cg.outputs[0].eval({x: 1., y: 1.}),
-                    2 + RandomStreams(1).normal().eval())
+    noised_cg = apply_noise(cg, [y], 1, 1)
+    assert_allclose(
+        noised_cg.outputs[0].eval({x: 1., y: 1.}),
+        2 + MRG_RandomStreams(1).normal(y.shape).eval({y: 1.}))


### PR DESCRIPTION
Instead, draw a seed from a global RNG for each brick. This prevents
bricks from having the exact same weight initialization.

Fixes #180.