### PR TITLE
Rename expressions

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -212,8 +212,7 @@ class StepRule(object):
         param : :class:`~tensor.TensorSharedVariable`
             The parameter.
         grad_wr_param : :class:`~tensor.TensorVariable`
-            The expression for the gradient of the cost with respect to
-            the parameter.
+            The gradient of the cost with respect to the parameter.
 
         Returns
         -------

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -831,14 +831,14 @@ class ApplicationCall(Annotation):
         self.application = application
         super(ApplicationCall, self).__init__()
 
-    def add_auxiliary_variable(self, expression, roles=None, name=None):
+    def add_auxiliary_variable(self, variable, roles=None, name=None):
         if name:
-            expression.name = _variable_name(
+            variable.name = _variable_name(
                 self.brick.name, self.application.name, name)
-            expression.tag.name = name
+            variable.tag.name = name
             name = None
         return super(ApplicationCall, self).add_auxiliary_variable(
-            expression, roles, name)
+            variable, roles, name)
 
 
 def application(*args, **kwargs):

--- a/blocks/extensions/monitoring.py
+++ b/blocks/extensions/monitoring.py
@@ -26,8 +26,8 @@ class DataStreamMonitoring(SimpleExtension):
     Parameters
     ----------
     variables : list of :class:`~tensor.TensorVariable`
-        The variables to monitor. The variable names are used as monitoring
-        channel names.
+        The variables to monitor. The variable names are used as record
+        names in the logs.
     data_stream : instance of :class:`.DataStream`
         The data stream to monitor on. A data epoch is requested
         each time monitoring is done.
@@ -69,8 +69,8 @@ class TrainingDataMonitoring(SimpleExtension):
     Parameters
     ----------
     variables : list of :class:`~tensor.TensorVariable`
-        The variables to monitor. The variable names are used as
-        variable names.
+        The variables to monitor. The variable names are used as record
+        names in the logs.
     prefix : str, optional
         A prefix to add to variable names when adding records to the
         log. An underscore will be used to separate the prefix.

--- a/blocks/extensions/monitoring.py
+++ b/blocks/extensions/monitoring.py
@@ -19,35 +19,35 @@ def _add_records(log, prefix, record_tuples):
 
 
 class DataStreamMonitoring(SimpleExtension):
-    """Monitors values of Theano expressions on a data stream.
+    """Monitors values of Theano variables on a data stream.
 
     By default monitoring is done before the first and after every epoch.
 
     Parameters
     ----------
-    expressions : list of :class:`~tensor.TensorVariable`
-        The expressions to monitor. The variable names are used as
-        expression names.
+    variables : list of :class:`~tensor.TensorVariable`
+        The variables to monitor. The variable names are used as monitoring
+        channel names.
     data_stream : instance of :class:`.DataStream`
         The data stream to monitor on. A data epoch is requested
         each time monitoring is done.
     prefix : str, optional
-        A prefix to add to expression names when adding records to the
-        log. An underscore will be used to separate the prefix.
+        A prefix to add to the names when adding records to the log. An
+        underscore will be used to separate the prefix.
 
     """
     PREFIX_SEPARATOR = '_'
 
-    def __init__(self, expressions, data_stream, prefix=None, **kwargs):
+    def __init__(self, variables, data_stream, prefix=None, **kwargs):
         kwargs.setdefault("after_every_epoch", True)
         kwargs.setdefault("before_first_epoch", True)
         super(DataStreamMonitoring, self).__init__(**kwargs)
-        self._evaluator = DatasetEvaluator(expressions)
+        self._evaluator = DatasetEvaluator(variables)
         self.data_stream = data_stream
         self.prefix = prefix
 
     def do(self, callback_name, *args):
-        """Write the values of monitored expressions to the log."""
+        """Write the values of monitored variables to the log."""
         logger.info("Monitoring on auxiliary data started")
         value_dict = self._evaluator.evaluate(self.data_stream)
         _add_records(self.main_loop.log, self.prefix, value_dict.items())
@@ -55,7 +55,7 @@ class DataStreamMonitoring(SimpleExtension):
 
 
 class TrainingDataMonitoring(SimpleExtension):
-    """Monitors values of Theano expressions on training batches.
+    """Monitors values of Theano variables on training batches.
 
     Use this extension to monitor a quantity on every training batch
     cheaply. It integrates with the training algorithm in order to avoid
@@ -63,31 +63,31 @@ class TrainingDataMonitoring(SimpleExtension):
     training a network and you want to log the norm of the gradient on
     every batch, the backpropagation will only be done once.  By
     controlling the frequency with which the :meth:`do` method is called,
-    you can aggregate the monitored expressions, e.g. only log the gradient
+    you can aggregate the monitored variables, e.g. only log the gradient
     norm average over an epoch.
 
     Parameters
     ----------
-    expressions : list of :class:`~tensor.TensorVariable`
-        The expressions to monitor. The variable names are used as
-        expression names.
+    variables : list of :class:`~tensor.TensorVariable`
+        The variables to monitor. The variable names are used as
+        variable names.
     prefix : str, optional
-        A prefix to add to expression names when adding records to the
+        A prefix to add to variable names when adding records to the
         log. An underscore will be used to separate the prefix.
 
     Notes
     -----
-    All the monitored expressions are evaluated _before_ the parameter
+    All the monitored variables are evaluated _before_ the parameter
     update.
 
     Requires the training algorithm to be an instance of
     :class:`.DifferentiableCostMinimizer`.
 
     """
-    def __init__(self, expressions, prefix=None, **kwargs):
+    def __init__(self, variables, prefix=None, **kwargs):
         kwargs.setdefault("before_training", True)
         super(TrainingDataMonitoring, self).__init__(**kwargs)
-        self._buffer = AggregationBuffer(expressions, use_take_last=True)
+        self._buffer = AggregationBuffer(variables, use_take_last=True)
         self._last_time_called = -1
         self.prefix = prefix
 
@@ -99,7 +99,7 @@ class TrainingDataMonitoring(SimpleExtension):
         aggregation buffer and instructs the training algorithm what
         additional computations should be carried at each step by adding
         corresponding updates to it. In all other cases it writes
-        aggregated values of the monitored expressions to the log.
+        aggregated values of the monitored variables to the log.
 
         """
         if callback_name == self.before_training.__name__:

--- a/blocks/graph.py
+++ b/blocks/graph.py
@@ -235,7 +235,7 @@ class Annotation(object):
         self.auxiliary_variables = []
         self.updates = OrderedDict()
 
-    def add_auxiliary_variable(self, expression, roles=None, name=None):
+    def add_auxiliary_variable(self, variable, roles=None, name=None):
         """Attach an auxiliary variable to the graph.
 
         Auxiliary variables are Theano variables that are not part of a
@@ -244,14 +244,14 @@ class Annotation(object):
 
         Parameters
         ----------
-        expression : :class:`~tensor.TensorVariable`
-            The expression of the variable you want to add.
+        variable : :class:`~tensor.TensorVariable`
+            The variable you want to add.
         roles : list of :class:`.VariableRole` instances, optional
             The roles of this variable. The :const:`.AUXILIARY`
             role will automatically be added. Other options are
             :const:`.COST`, :const:`.WEIGHTS`, etc.
         name : str, optional
-            The name of the expression; overrides the name of the variable
+            The name of the variable; overrides the name of the variable
             if it already has one.
 
         Examples
@@ -283,15 +283,15 @@ class Annotation(object):
         {mean_x}
 
         """
-        add_annotation(expression, self)
+        add_annotation(variable, self)
         if name is not None:
-            expression.name = name
-            expression.tag.name = name
-        add_role(expression, AUXILIARY)
+            variable.name = name
+            variable.tag.name = name
+        add_role(variable, AUXILIARY)
         if roles is not None:
             for role in roles:
-                add_role(expression, role)
-        self.auxiliary_variables.append(expression)
+                add_role(variable, role)
+        self.auxiliary_variables.append(variable)
 
 
 def apply_noise(graph, variables, level, seed=None):

--- a/blocks/graph.py
+++ b/blocks/graph.py
@@ -251,8 +251,8 @@ class Annotation(object):
             role will automatically be added. Other options are
             :const:`.COST`, :const:`.WEIGHTS`, etc.
         name : str, optional
-            The name of the variable; overrides the name of the variable
-            if it already has one.
+            Name to give to the variable. If the variable already has a
+            name it will be overwritten.
 
         Examples
         --------

--- a/blocks/monitoring/aggregation.py
+++ b/blocks/monitoring/aggregation.py
@@ -115,7 +115,7 @@ class Mean(AggregationScheme):
                                 initialization_updates=initialization_updates,
                                 accumulation_updates=accumulation_updates,
                                 readout_variable=(numerator_acc /
-                                                    denominator_acc))
+                                                  denominator_acc))
         return aggregator
 
 

--- a/blocks/monitoring/aggregation.py
+++ b/blocks/monitoring/aggregation.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 @add_metaclass(ABCMeta)
 class AggregationScheme(object):
-    """Specify how incrementally evaluate a Theano expression on a dataset.
+    """How to incrementally evaluate a Theano variable over minibatches.
 
     An AggregationScheme allocates :class:`Aggregator`s that can
     incrementally compute the value of a Theano variable on a full dataset

--- a/blocks/monitoring/aggregation.py
+++ b/blocks/monitoring/aggregation.py
@@ -1,4 +1,4 @@
-"""Evaluate Theano expressions on auxiliary data and during training."""
+"""Evaluate Theano variables on auxiliary data and during training."""
 import logging
 from abc import ABCMeta, abstractmethod
 
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 @add_metaclass(ABCMeta)
 class AggregationScheme(object):
-    """Specify how incrementally evaluate a Theano variable on a dataset.
+    """Specify how incrementally evaluate a Theano expression on a dataset.
 
     An AggregationScheme allocates :class:`Aggregator`s that can
     incrementally compute the value of a Theano variable on a full dataset
@@ -24,8 +24,8 @@ class AggregationScheme(object):
 
     Parameters
     ----------
-    expression: :class:`~tensor.TensorVariable`
-        expression that computes the desired value on a single batch.
+    variable: :class:`~tensor.TensorVariable`
+        The variable that holds the desired value on a single batch.
 
     """
     @abstractmethod
@@ -50,7 +50,7 @@ class Aggregator(object):
     The Aggregator maintains a set of Theano sharer values called
     accumulators and specifies how they should be initialized, and
     updated with incremental calculations. Finally, it
-    provides a Theano expression that reads the accumulators
+    provides a Theano variable that reads the accumulators
     and computes the final value.
 
     Parameters
@@ -64,9 +64,9 @@ class Aggregator(object):
     accumulation_updates : list of Theano updates
         Updates that specify how a new batch of data gets processed
         by this Aggregator. *Can refer to model inputs.*
-    readout_expression : :class:`~tensor.TensorVariable`
-        Theano variable that computes the final value based on accumulated
-        partial results. *readout_expression must only consist of shared
+    readout_variable : :class:`~tensor.TensorVariable`
+        Theano variable that holds the final value based on accumulated
+        partial results. *readout_variable must only consist of shared
         variables and constants.*
 
     Attributes
@@ -75,9 +75,9 @@ class Aggregator(object):
 
     """
     def __init__(self, aggregation_scheme, initialization_updates=None,
-                 accumulation_updates=None, readout_expression=None):
+                 accumulation_updates=None, readout_variable=None):
         self.aggregation_scheme = aggregation_scheme
-        self.readout_expression = readout_expression
+        self.readout_variable = readout_variable
 
         if initialization_updates is None:
             initialization_updates = []
@@ -93,9 +93,9 @@ class Mean(AggregationScheme):
     Parameters
     ----------
     numerator : :class:`~tensor.TensorVariable`
-        Theano expression for the numerator e.g. the likelihood
+        Theano variable for the numerator e.g. the likelihood
     denominator : :class:`~tensor.TensorVariable`
-        Theano expression for the denominator e.g. the batch size
+        Theano variable for the denominator e.g. the batch size
 
     """
     def __init__(self, numerator, denominator):
@@ -114,17 +114,17 @@ class Mean(AggregationScheme):
         aggregator = Aggregator(aggregation_scheme=self,
                                 initialization_updates=initialization_updates,
                                 accumulation_updates=accumulation_updates,
-                                readout_expression=(numerator_acc /
+                                readout_variable=(numerator_acc /
                                                     denominator_acc))
         return aggregator
 
 
 def mean(numerator, denominator=1.0):
     """Mean of quantity (numerator) over a number (denominator) values."""
-    expression = numerator / denominator
-    expression.tag.aggregation_scheme = Mean(numerator, denominator)
-    expression.name = numerator.name
-    return expression
+    variable = numerator / denominator
+    variable.tag.aggregation_scheme = Mean(numerator, denominator)
+    variable.name = numerator.name
+    return variable
 
 
 class _DataIndependent(AggregationScheme):
@@ -136,7 +136,7 @@ class _DataIndependent(AggregationScheme):
         return Aggregator(aggregation_scheme=self,
                           initialization_updates=[],
                           accumulation_updates=[],
-                          readout_expression=self.variable)
+                          readout_variable=self.variable)
 
 
 class TakeLast(AggregationScheme):
@@ -150,4 +150,4 @@ class TakeLast(AggregationScheme):
                           initialization_updates=[
                               (self.storage, tensor.zeros_like(self.storage))],
                           accumulation_updates=[(self.storage, self.variable)],
-                          readout_expression=self.storage)
+                          readout_variable=self.storage)

--- a/blocks/monitoring/evaluators.py
+++ b/blocks/monitoring/evaluators.py
@@ -35,7 +35,8 @@ class AggregationBuffer(object):
     accumulation_updates : list of tuples
         Accumulation updates of the aggregators.
     readout_variables : dict
-        Maps an aggregated variable into a readout variable.
+        A dictionary of record names to :class:`~tensor.TensorVariable`
+        representing the aggregated values.
     input : list of :class:`~tensor.TensorVariable`
         The list of inputs needed for accumulation.
     input_names : list of str
@@ -146,10 +147,9 @@ class DatasetEvaluator(object):
 
     Parameters
     ----------
-    variables : dict or list
-        If a list of :class:`~tensor.TensorVariable` then the variable names
-        are used as record names in the logs, else the dictionary keys are
-        used. All the names must be different.
+    variables : list of :class:`~tensor.TensorVariable`
+        The variable names are used as record names in the logs. Hence, all
+        the names must be different.
 
         Each variable can be tagged with an :class:`AggregationScheme` that
         specifies how the value can be computed for a data set by

--- a/blocks/utils.py
+++ b/blocks/utils.py
@@ -101,24 +101,24 @@ def shared_floatx(value, name=None, borrow=False, dtype=None):
                          borrow=borrow)
 
 
-def shared_like(expression, name=None):
-    """Construct a shared variable to hold the results of a theano expression.
+def shared_like(variable, name=None):
+    """Construct a shared variable to hold the value of a tensor variable.
 
     Parameters
     ----------
-    expression : :class:`~tensor.TensorVariable`
-        The expression whose dtype and ndim will be used to construct
+    variable : :class:`~tensor.TensorVariable`
+        The variable whose dtype and ndim will be used to construct
         the new shared variable.
     name : :obj:`str` or :obj:`None`
         The name of the shared variable. If None, the name is determined
-        based on expression's name.
+        based on variable's name.
 
     """
-    expression = tensor.as_tensor_variable(expression)
+    variable = tensor.as_tensor_variable(variable)
     if name is None:
-        name = "shared_{}".format(expression.name)
-    return theano.shared(numpy.zeros((0,) * expression.ndim,
-                                     dtype=expression.dtype),
+        name = "shared_{}".format(variable.name)
+    return theano.shared(numpy.zeros((0,) * variable.ndim,
+                                     dtype=variable.dtype),
                          name=name)
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,7 +94,7 @@ And train!
 ...         cost=cost, step_rule=SteepestDescent(learning_rate=0.1)),
 ...     extensions=[FinishAfter(after_n_epochs=5),
 ...                 DataStreamMonitoring(
-...                     expressions=[cost, error_rate],
+...                     variables=[cost, error_rate],
 ...                     data_stream=test_stream,
 ...                     prefix="test"),
 ...                 Printing()])

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -188,7 +188,7 @@ to use one of Blocks' extensions. In particular, we need to use the
 
 >>> from blocks.extensions.monitoring import DataStreamMonitoring
 >>> monitor = DataStreamMonitoring(
-...     expressions=[cost], data_stream=data_stream_test, prefix="test")
+...     variables=[cost], data_stream=data_stream_test, prefix="test")
 
 We can use the :class:`.MainLoop` to combine all the different
 bits and pieces now. We use two more extensions to make our training stop after

--- a/tests/monitoring/test_aggregation.py
+++ b/tests/monitoring/test_aggregation.py
@@ -51,4 +51,4 @@ def test_param_monitor():
     accumulate = theano.function([X], updates=aggregator.accumulation_updates)
     accumulate(numpy.arange(4, dtype=theano.config.floatX).reshape(2, 2))
     accumulate(numpy.arange(4, 10, dtype=theano.config.floatX).reshape(3, 2))
-    assert_allclose(aggregator.readout_expression.eval(), 4.5)
+    assert_allclose(aggregator.readout_variable.eval(), 4.5)


### PR DESCRIPTION
@rizar To solve all the confusion

Rename expressions to variables in order to distinguish clearly between a Theano expression (e.g. x + y) and its result (which is a variable). Hence all arguments and return values of functions are variables (not expressions). Functions and methods can represent Theano expressions.