### PR TITLE
Convert log to pandas.DataFrame

### DIFF
--- a/blocks/log.py
+++ b/blocks/log.py
@@ -3,6 +3,11 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
 from six import add_metaclass
+try:
+    from pandas import DataFrame
+    pandas_available = True
+except:
+    pandas_available = False
 
 
 @add_metaclass(ABCMeta)
@@ -203,6 +208,10 @@ class AbstractTrainingLog(object):
         if not isinstance(time, int) or time < 0:
             raise ValueError("time must be a positive integer")
 
+    def to_dataframe(log):
+        """Convert to :class:`.DataFrame`."""
+        raise NotImplementedError
+
 
 class TrainingStatus(AbstractTrainingStatus):
     """A simple training status."""
@@ -245,3 +254,18 @@ class TrainingLog(AbstractTrainingLog):
 
     def get_status(self):
         return self._status
+
+    def to_dataframe(self):
+        return DataFrame.from_dict(self._storage, orient='index')
+
+
+def to_dataframe(log):
+    """Convert a log into a :class:`.DataFrame`."""
+    if not pandas_available:
+        raise Exception("The pandas library is not found. You can"
+                        " install it with pip.")
+    try:
+        return log.to_dataframe()
+    except NotImplementedError:
+        # TODO: some default method of converting a log into a dataframe
+        raise

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -208,14 +208,14 @@ class AbstractTrainingLog(object):
         if not isinstance(time, int) or time < 0:
             raise ValueError("time must be a positive integer")
 
-    def to_dataframe(log):
+    def to_dataframe(self):
         """Convert a log into a :class:`.DataFrame`."""
         if not pandas_available:
             raise ImportError("The pandas library is not found. You can"
                               " install it with pip.")
-        return log._to_dataframe()
+        return self._to_dataframe()
 
-    def _to_dataframe(log):
+    def _to_dataframe(self):
         raise NotImplementedError()
 
 

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -209,8 +209,14 @@ class AbstractTrainingLog(object):
             raise ValueError("time must be a positive integer")
 
     def to_dataframe(log):
-        """Convert to :class:`.DataFrame`."""
-        raise NotImplementedError
+        """Convert a log into a :class:`.DataFrame`."""
+        if not pandas_available:
+            raise ImportError("The pandas library is not found. You can"
+                              " install it with pip.")
+        return log._to_dataframe()
+
+    def _to_dataframe(log):
+        raise NotImplementedError()
 
 
 class TrainingStatus(AbstractTrainingStatus):
@@ -255,17 +261,5 @@ class TrainingLog(AbstractTrainingLog):
     def get_status(self):
         return self._status
 
-    def to_dataframe(self):
+    def _to_dataframe(self):
         return DataFrame.from_dict(self._storage, orient='index')
-
-
-def to_dataframe(log):
-    """Convert a log into a :class:`.DataFrame`."""
-    if not pandas_available:
-        raise Exception("The pandas library is not found. You can"
-                        " install it with pip.")
-    try:
-        return log.to_dataframe()
-    except NotImplementedError:
-        # TODO: some default method of converting a log into a dataframe
-        raise

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,8 @@ extensions = [
 intersphinx_mapping = {
     'theano': ('http://theano.readthedocs.org/en/latest/', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
-    'python': ('http://docs.python.org/3.4', None)
+    'python': ('http://docs.python.org/3.4', None),
+    'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None)
 }
 
 graphviz_dot_args = ['-Gbgcolor=#fcfcfc']  # To match the RTD theme

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     keywords='theano machine learning neural networks deep learning',
     packages=find_packages(exclude=['examples', 'docs', 'tests']),
     scripts=['bin/blocks-continue', 'bin/blocks-dump'],
-    install_requires=['dill', 'numpy', 'theano', 'six', 'pyyaml'],
+    install_requires=['dill', 'numpy', 'theano', 'six', 'pyyaml', 'pandas'],
     extras_require={
         'test': ['nose', 'nose2'],
         'plot': ['bokeh'],

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,7 +1,7 @@
-from blocks.log import TrainingLog
+from blocks.log import TrainingLog, to_dataframe
 
 
-def test_ram_training_log():
+def test_training_log():
     log = TrainingLog()
 
     # test basic writing capabilities
@@ -21,3 +21,7 @@ def test_ram_training_log():
 
     # test iteration
     assert len(list(log)) == 2
+    df = to_dataframe(log)
+    assert list(sorted(df.columns)) == ["field", "flag"]
+    assert df.flag[1] is False
+    assert df.field[0] == 45

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,4 +1,4 @@
-from blocks.log import TrainingLog, to_dataframe
+from blocks.log import TrainingLog
 
 
 def test_training_log():
@@ -21,7 +21,7 @@ def test_training_log():
 
     # test iteration
     assert len(list(log)) == 2
-    df = to_dataframe(log)
+    df = log.to_dataframe()
     assert list(sorted(df.columns)) == ["field", "flag"]
     assert df.flag[1] is False
     assert df.field[0] == 45


### PR DESCRIPTION
Our current log provides absolute no means for data analysis. And it shouldn't: there is pandas for it. Currently there is only one log and it is  very easy to convert to a `DataFrame` (see the code), but we should have more, and for some of them, e.g. for a one based on sqlite, there will be no easy strategy for conversion. That's why I reserve a place for a generic implementation that will use the log's public interface.