### PR TITLE
Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,6 @@ script:
       export THEANO_FLAGS=floatX=$TESTS
       # Running nose2 within coverage makes imports count towards coverage
       bokeh-server &> /dev/null &
-      coverage run --source=blocks -m nose2.__main__ tests
+      coverage run --source=blocks -m nose2.__main__ -v tests
 after_script:
   - coveralls

--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -343,7 +343,7 @@ class ContainerDataset(Dataset):
 
     .. todo::
 
-        Multiple containers, returning batches.
+        Multiple containers.
 
     Parameters
     ----------
@@ -355,6 +355,11 @@ class ContainerDataset(Dataset):
         source names. Note, that only if the container is an OrderedDict
         the order of elements in the returned tuples is determined. If the
         iterable is not a dictionary, the source ``data`` will be used.
+
+    Notes
+    -----
+    To iterate over a container in batches, combine this dataset with the
+    :class:`BatchDataStream` data stream.
 
     """
     default_scheme = None
@@ -377,15 +382,8 @@ class ContainerDataset(Dataset):
             lambda: tuple([next(iterator) for iterator in iterators]))
 
     def get_data(self, state=None, request=None):
-        if request is not None:
-            try:
-                batch = []
-                for _ in range(request):
-                    batch.append(next(state))
-            except StopIteration:
-                if not batch:
-                    raise
-            return tuple(zip(*batch))
+        if state is None or request is not None:
+            raise ValueError
         return next(state)
 
 
@@ -692,16 +690,19 @@ class BatchDataStream(DataStreamWrapper):
     iteration_scheme : :class:`.BatchSizeScheme` instance
         The iteration scheme to use; should return integers representing
         the size of the batch to return.
-    strict : bool, optional
-        Whether the batch size should be strictly adhered to or not. For
-        example, if the dataset ends before the last batch is being filled,
-        can a smaller batch still be returned? By default ``False``.
+    strictness : int, optional
+        How strictly the iterator should adhere to the batch size. By
+        default, the value 0 means that the last batch is returned
+        regardless of its size, so it can be smaller than what is actually
+        requested. At level 1, the last batch is discarded if it is not of
+        the correct size. At the highest strictness level, 2, an error is
+        raised if a batch of the requested size cannot be provided.
 
     """
-    def __init__(self, data_stream, iteration_scheme, strict=False):
+    def __init__(self, data_stream, iteration_scheme, strictness=0):
         super(BatchDataStream, self).__init__(
             data_stream, iteration_scheme=iteration_scheme)
-        self.strict = strict
+        self.strictness = strictness
 
     def get_data(self, request=None):
         """Get data from the dataset."""
@@ -714,13 +715,12 @@ class BatchDataStream(DataStreamWrapper):
                         data, next(self.child_epoch_iterator)):
                     source_data.append(example)
             except StopIteration:
-                if self.strict and data[0]:
-                    raise ValueError("Not enough examples to form a batch of"
-                                     " requested size")
                 # If some data has been extracted and `strict` is not set,
                 # we should spit out this data before stopping iteration.
-                if data[0]:
+                if not self.strictness and data[0]:
                     break
+                elif self.strictness > 1 and data[0]:
+                    raise ValueError
                 raise
         return tuple(numpy.asarray(source_data) for source_data in data)
 

--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -354,7 +354,7 @@ class ContainerDataset(Dataset):
         values are interpreted as data channels and its keys are used as
         source names. Note, that only if the container is an OrderedDict
         the order of elements in the returned tuples is determined. If the
-        iterable is not a dictionary, the source ``'data'`` will be used.
+        iterable is not a dictionary, the source ``data`` will be used.
 
     """
     default_scheme = None
@@ -377,8 +377,15 @@ class ContainerDataset(Dataset):
             lambda: tuple([next(iterator) for iterator in iterators]))
 
     def get_data(self, state=None, request=None):
-        if state is None or request is not None:
-            raise ValueError
+        if request is not None:
+            try:
+                batch = []
+                for _ in range(request):
+                    batch.append(next(state))
+            except StopIteration:
+                if not batch:
+                    raise
+            return tuple(zip(*batch))
         return next(state)
 
 

--- a/blocks/datasets/schemes.py
+++ b/blocks/datasets/schemes.py
@@ -74,9 +74,9 @@ class ConstantScheme(BatchSizeScheme):
         The size of the batch to return.
     num_examples : int, optional
         If given, the request iterator will return `batch_size` until the
-        sum reaches `num_exampes`. Note that this means that the last batch
-        size returned could be smaller than `batch_size`. If you want to
-        ensure all batches are of equal size, then pass `times` equal to
+        sum reaches `num_exam;pes`. Note that this means that the last
+        batch size returned could be smaller than `batch_size`. If you want
+        to ensure all batches are of equal size, then pass `times` equal to
         ``num_examples / batch-size`` instead.
     times : int, optional
         The number of times to return `batch_size`.

--- a/blocks/datasets/schemes.py
+++ b/blocks/datasets/schemes.py
@@ -106,13 +106,15 @@ class ConstantIterator(six.Iterator):
 
     def __next__(self):
         if self.times or self.num_examples:
-            if self.current == self.times:
+            if self.current == self.times or self.current == self.num_examples:
                 raise StopIteration
             if self.times:
                 self.current += 1
             else:
-                self.current += self.batch_size
-                return min(self.batch_size, self.num_examples - self.current)
+                batch_size = min(self.batch_size,
+                                 self.num_examples - self.current)
+                self.current += batch_size
+                return batch_size
         return self.batch_size
 
 

--- a/blocks/datasets/schemes.py
+++ b/blocks/datasets/schemes.py
@@ -98,7 +98,8 @@ class ConstantIterator(six.Iterator):
         if num_examples is not None and times is not None:
             raise ValueError
         if times is not None or num_examples is not None:
-            if not (times >= 1 or num_examples >= 1):
+            if not ((times is None or times >= 1) or
+                    (num_examples is None or num_examples >= 1)):
                 raise ValueError
             self.current = 0
 

--- a/blocks/dump.py
+++ b/blocks/dump.py
@@ -156,11 +156,11 @@ class MainLoopDumpManager(object):
 
     @property
     def path_to_parameters(self):
-        return "{}/{}".format(self.folder, "params.npz")
+        return os.path.join(self.folder, 'params.npz')
 
     @property
     def path_to_iteration_state(self):
-        return "{}/{}".format(self.folder, "iteration_state.pkl")
+        return os.path.join(self.folder, 'iterations_state.pkl')
 
     @property
     def path_to_log(self):
@@ -169,7 +169,7 @@ class MainLoopDumpManager(object):
         # then pickled file. Or alternatively, log will be dump as pure
         # text file of (time, key, value) triples. Currenly log is just
         # pickled though.
-        return "{}/{}".format(self.folder, "log")
+        return os.path.join(self.folder, 'log')
 
     def dump_parameters(self, main_loop):
         save_parameter_values(extract_parameter_values(main_loop.model),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,5 @@
-import os
 import sys
-import shutil
 from functools import wraps
-from unittest import SkipTest
 
 from six import StringIO
 
@@ -17,21 +14,3 @@ def silence_printing(test):
         finally:
             sys.stdout = stdout
     return wrapper
-
-
-def temporary_files(*files):
-    def wrap_test(test):
-        @wraps(test)
-        def wrapped_test(*args, **kwargs):
-            if any(os.path.exists(file_) for file_ in files):
-                raise SkipTest
-            try:
-                test(*args, **kwargs)
-            finally:
-                for file_ in files:
-                    if os.path.exists(file_):
-                        rm = (shutil.rmtree if os.path.isdir(file_)
-                              else os.remove)
-                        rm(file_)
-        return wrapped_test
-    return wrap_test

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,31 +1,30 @@
 import os
 import sys
 import shutil
-from functools import update_wrapper
+from functools import wraps
+from unittest import SkipTest
 
-
-class Discarder(object):
-    def write(self, text):
-        pass
+from six import StringIO
 
 
 def silence_printing(test):
+    @wraps(test)
     def wrapper(*args, **kwargs):
         stdout = sys.stdout
-        sys.stdout = Discarder()
+        sys.stdout = StringIO()
         try:
             test(*args, **kwargs)
         finally:
             sys.stdout = stdout
-    update_wrapper(wrapper, test)
     return wrapper
 
 
 def temporary_files(*files):
     def wrap_test(test):
+        @wraps(test)
         def wrapped_test(*args, **kwargs):
             if any(os.path.exists(file_) for file_ in files):
-                raise IOError
+                raise SkipTest
             try:
                 test(*args, **kwargs)
             finally:
@@ -34,6 +33,5 @@ def temporary_files(*files):
                         rm = (shutil.rmtree if os.path.isdir(file_)
                               else os.remove)
                         rm(file_)
-        update_wrapper(wrapped_test, test)
         return wrapped_test
     return wrap_test

--- a/tests/datasets/test_schemes.py
+++ b/tests/datasets/test_schemes.py
@@ -32,10 +32,11 @@ def test_sequential_scheme():
 
 def test_shuffled_scheme():
     get_request_iterator = iterator_requester(ShuffledScheme)
-    indices = range(7)
+    indices = numpy.arange(7)
     rng = numpy.random.RandomState(3)
     test_rng = numpy.random.RandomState(3)
     test_rng.shuffle(indices)
+    indices = indices.tolist()
     assert list(get_request_iterator(7, 3, rng=rng)) == \
         [indices[:3], indices[3:6], indices[6:]]
     assert list(get_request_iterator(7, 3, rng=rng)) != \

--- a/tests/datasets/test_schemes.py
+++ b/tests/datasets/test_schemes.py
@@ -1,0 +1,28 @@
+from numpy.testing import assert_raises
+
+from blocks.datasets.schemes import ConstantScheme, SequentialScheme
+
+
+def iterator_requester(scheme):
+    def get_request_iterator(*args, **kwargs):
+        scheme_obj = scheme(*args, **kwargs)
+        return scheme_obj.get_request_iterator()
+    return get_request_iterator
+
+
+def test_constant_scheme():
+    get_request_iterator = iterator_requester(ConstantScheme)
+    assert list(get_request_iterator(3, num_examples=7)) == [3, 3, 1]
+    assert list(get_request_iterator(3, num_examples=9)) == [3, 3, 3]
+    assert list(get_request_iterator(3, num_examples=2)) == [2]
+    assert list(get_request_iterator(2, times=3)) == [2, 2, 2]
+    assert list(get_request_iterator(3, times=1)) == [3]
+    it = get_request_iterator(3)
+    assert [next(it) == 3 for _ in range(10)]
+    assert_raises(ValueError, get_request_iterator, 10, 2, 2)
+
+
+def test_sequential_scheme():
+    get_request_iterator = iterator_requester(SequentialScheme)
+    assert list(get_request_iterator(5, 3)) == [[0, 1, 2], [3, 4]]
+    assert list(get_request_iterator(4, 2)) == [[0, 1], [2, 3]]

--- a/tests/datasets/test_schemes.py
+++ b/tests/datasets/test_schemes.py
@@ -1,6 +1,8 @@
+import numpy
 from numpy.testing import assert_raises
 
-from blocks.datasets.schemes import ConstantScheme, SequentialScheme
+from blocks.datasets.schemes import (ConstantScheme, SequentialScheme,
+                                     ShuffledScheme)
 
 
 def iterator_requester(scheme):
@@ -26,3 +28,15 @@ def test_sequential_scheme():
     get_request_iterator = iterator_requester(SequentialScheme)
     assert list(get_request_iterator(5, 3)) == [[0, 1, 2], [3, 4]]
     assert list(get_request_iterator(4, 2)) == [[0, 1], [2, 3]]
+
+
+def test_shuffled_scheme():
+    get_request_iterator = iterator_requester(ShuffledScheme)
+    indices = range(7)
+    rng = numpy.random.RandomState(3)
+    test_rng = numpy.random.RandomState(3)
+    test_rng.shuffle(indices)
+    assert list(get_request_iterator(7, 3, rng=rng)) == \
+        [indices[:3], indices[3:6], indices[6:]]
+    assert list(get_request_iterator(7, 3, rng=rng)) != \
+        [indices[:3], indices[3:6], indices[6:]]

--- a/tests/datasets/test_serialization.py
+++ b/tests/datasets/test_serialization.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 import dill
 import numpy
@@ -6,10 +7,8 @@ import numpy
 from blocks.datasets import DataStream
 from blocks.datasets.mnist import MNIST
 from blocks.datasets.schemes import SequentialScheme
-from tests import temporary_files
 
 
-@temporary_files('epoch_test.pkl')
 def test_in_memory():
     # Load MNIST and get two batches
     mnist = MNIST('train')
@@ -22,9 +21,8 @@ def test_in_memory():
     assert numpy.all(features == mnist.features[256:512])
 
     # Pickle the epoch and make sure that the data wasn't dumped
-    filename = 'epoch_test.pkl'
-    assert not os.path.exists(filename)
-    with open(filename, 'wb') as f:
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        filename = f.name
         dill.dump(epoch, f, fmode=dill.CONTENTS_FMODE)
     assert os.path.getsize(filename) < 1024 * 1024  # Less than 1MB
 

--- a/tests/datasets/test_text.py
+++ b/tests/datasets/test_text.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import dill
 from numpy.testing import assert_raises
 from six import BytesIO
@@ -6,17 +8,18 @@ from blocks.datasets.text import TextFile
 from tests import temporary_files
 
 
-@temporary_files('sentences1.txt', 'sentences2.txt')
 def test_text():
     # Test word level and epochs.
-    with open('sentences1.txt', 'w') as f:
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        sentences1 = f.name
         f.write("This is a sentence\n")
         f.write("This another one")
-    with open('sentences2.txt', 'w') as f:
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        sentences2 = f.name
         f.write("More sentences\n")
         f.write("The last one")
     dictionary = {'<UNK>': 0, '</S>': 1, 'this': 2, 'a': 3, 'one': 4}
-    text_data = TextFile(files=['sentences1.txt', 'sentences2.txt'],
+    text_data = TextFile(files=[sentences1, sentences2],
                          dictionary=dictionary, bos_token=None,
                          preprocess=str.lower)
     stream = text_data.get_default_stream()
@@ -37,7 +40,7 @@ def test_text():
     dictionary = dict([(chr(ord('a') + i), i) for i in range(26)]
                       + [(' ', 26)] + [('<S>', 27)]
                       + [('</S>', 28)] + [('<UNK>', 29)])
-    text_data = TextFile(files=['sentences1.txt', 'sentences2.txt'],
+    text_data = TextFile(files=[sentences1, sentences2],
                          dictionary=dictionary, preprocess=str.lower,
                          level="character")
     sentence = next(text_data.get_default_stream().get_epoch_iterator())[0]

--- a/tests/datasets/test_text.py
+++ b/tests/datasets/test_text.py
@@ -5,16 +5,15 @@ from numpy.testing import assert_raises
 from six import BytesIO
 
 from blocks.datasets.text import TextFile
-from tests import temporary_files
 
 
 def test_text():
     # Test word level and epochs.
-    with tempfile.NamedTemporaryFile(delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
         sentences1 = f.name
         f.write("This is a sentence\n")
         f.write("This another one")
-    with tempfile.NamedTemporaryFile(delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
         sentences2 = f.name
         f.write("More sentences\n")
         f.write("The last one")

--- a/tests/datasets/test_text.py
+++ b/tests/datasets/test_text.py
@@ -1,11 +1,12 @@
 import dill
 from numpy.testing import assert_raises
+from six import BytesIO
 
 from blocks.datasets.text import TextFile
 from tests import temporary_files
 
 
-@temporary_files('sentences1.txt', 'sentences2.txt', 'text_stream.pkl')
+@temporary_files('sentences1.txt', 'sentences2.txt')
 def test_text():
     # Test word level and epochs.
     with open('sentences1.txt', 'w') as f:
@@ -24,11 +25,11 @@ def test_text():
     epoch = stream.get_epoch_iterator()
     for sentence in zip(range(3), epoch):
         pass
-    with open('text_stream.pkl', 'wb') as f:
-        dill.dump(epoch, f, fmode=dill.CONTENTS_FMODE)
+    f = BytesIO()
+    dill.dump(epoch, f, fmode=dill.CONTENTS_FMODE)
     sentence = next(epoch)
-    with open('text_stream.pkl', 'rb') as f:
-        epoch = dill.load(f)
+    f.seek(0)
+    epoch = dill.load(f)
     assert next(epoch) == sentence
     assert_raises(StopIteration, next, epoch)
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -4,15 +4,13 @@ import tempfile
 from numpy.testing import assert_raises
 
 from blocks.config_parser import Configuration, ConfigurationError
-from tests import temporary_files
 
 
-@temporary_files('.test_blocksrc')
 def test_config_parser():
     _environ = dict(os.environ)
     try:
 
-        with tempfile.NamedTemporaryFile(delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
             f.write('data_path: yaml_path')
             filename = f.name
         os.environ['BLOCKS_CONFIG'] = filename

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -9,13 +9,13 @@ from tests import temporary_files
 @temporary_files('.test_blocksrc')
 def test_config_parser():
     _environ = dict(os.environ)
-    os.environ['BLOCKS_CONFIG'] = os.path.join(os.getcwd(),
-                                               '.test_blocksrc')
-    with open(os.environ['BLOCKS_CONFIG'], 'w') as f:
-        f.write('data_path: yaml_path')
-    if 'BLOCKS_DATA_PATH' in os.environ:
-        del os.environ['BLOCKS_DATA_PATH']
     try:
+        os.environ['BLOCKS_CONFIG'] = os.path.join(os.getcwd(),
+                                                   '.test_blocksrc')
+        with open(os.environ['BLOCKS_CONFIG'], 'w') as f:
+            f.write('data_path: yaml_path')
+        if 'BLOCKS_DATA_PATH' in os.environ:
+            del os.environ['BLOCKS_DATA_PATH']
         config = Configuration()
         config.add_config('data_path', str, env_var='BLOCKS_DATA_PATH')
         config.add_config('config_with_default', int, default='1',

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 from numpy.testing import assert_raises
 
@@ -10,10 +11,11 @@ from tests import temporary_files
 def test_config_parser():
     _environ = dict(os.environ)
     try:
-        os.environ['BLOCKS_CONFIG'] = os.path.join(os.getcwd(),
-                                                   '.test_blocksrc')
-        with open(os.environ['BLOCKS_CONFIG'], 'w') as f:
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write('data_path: yaml_path')
+            filename = f.name
+        os.environ['BLOCKS_CONFIG'] = filename
         if 'BLOCKS_DATA_PATH' in os.environ:
             del os.environ['BLOCKS_DATA_PATH']
         config = Configuration()

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import numpy
 import theano
 
@@ -7,15 +9,14 @@ from blocks.dump import (
     load_parameter_values, save_parameter_values,
     extract_parameter_values, inject_parameter_values,
     MainLoopDumpManager)
-from tests import temporary_files, silence_printing
+from tests import silence_printing
 
 floatX = theano.config.floatX
 
 
-@temporary_files("__tmp.npz")
 def test_save_load_parameter_values():
     param_values = [("/a/b", numpy.zeros(3)), ("/a/c", numpy.ones(4))]
-    filename = "__tmp.npz"
+    filename = tempfile.mkdtemp() + 'params.npz'
     save_parameter_values(dict(param_values), filename)
     loaded_values = sorted(list(load_parameter_values(filename).items()),
                            key=lambda tuple_: tuple_[0])
@@ -46,7 +47,6 @@ def test_inject_parameter_values():
     assert numpy.all(mlp.linear_transformations[0].params[1].get_value() == 3)
 
 
-@temporary_files("__sqrt_folder", "__sqrt_folder2")
 @silence_printing
 def test_main_loop_state_manager():
     def assert_equal(main_loop1, main_loop2, check_log=True):
@@ -68,8 +68,8 @@ def test_main_loop_state_manager():
             next(main_loop1.epoch_iterator)["numbers"] ==
             next(main_loop2.epoch_iterator)["numbers"])
 
-    folder = '__sqrt_folder'
-    folder2 = folder + '2'
+    folder = tempfile.mkdtemp()
+    folder2 = tempfile.mkdtemp()
 
     main_loop1 = sqrt_example(folder, 17)
     assert main_loop1.log.status.epochs_done == 3

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,5 @@
 import logging
+import tempfile
 
 import dill
 
@@ -7,7 +8,7 @@ from blocks.extensions.saveload import SAVED_TO
 from examples.sqrt import main as sqrt_test
 from examples.mnist import main as mnist_test
 from examples.markov_chain.main import main as markov_chain_test
-from tests import temporary_files, silence_printing
+from tests import silence_printing
 
 
 def setup():
@@ -16,19 +17,18 @@ def setup():
     logger.setLevel(logging.ERROR)
 
 
-@temporary_files('__sqrt')
 @silence_printing
 def test_sqrt():
-    filename = '__sqrt'
-    sqrt_test(filename, 7)
-    main_loop = sqrt_test(filename, 14, continue_=True)
-    assert main_loop.log[7][SAVED_TO] == filename
+    save_path = tempfile.mkdtemp()
+    sqrt_test(save_path, 7)
+    main_loop = sqrt_test(save_path, 14, continue_=True)
+    assert main_loop.log[7][SAVED_TO] == save_path
 
 
-@temporary_files('mnist.pkl')
 @silence_printing
 def test_mnist():
-    filename = 'mnist.pkl'
+    f = tempfile.NamedTemporaryFile(delete=False)
+    filename = f.name
     mnist_test(filename, 1)
     with open(filename, "rb") as source:
         main_loop = dill.load(source)
@@ -39,10 +39,10 @@ def test_mnist():
 test_mnist.setup = setup
 
 
-@temporary_files('chain.pkl')
 @silence_printing
 def test_markov_chain():
-    filename = 'chain.pkl'
+    f = tempfile.NamedTemporaryFile(delete=False)
+    filename = f.name
     markov_chain_test("train", filename, None, 10)
 
 test_mnist.setup = setup


### PR DESCRIPTION
Bits and pieces:

* Use `ContainerDataset` for `test_cache` so that it can run without MNIST
* Introduce a scheme for shuffled batches
* Add functionality to `ConstantScheme`, allowing it to return batch sizes until they sum to a given `num_examples`
* Use `BytesIO` instead of files where possible
* ~~Skip tests instead of failing if files already exist~~
* Use `tempfile` to create temporary files instead of creating files in the working directory
* Make the tests on Travis more verbose, so that we can see at which test it stalls