### PR TITLE
Switch back to coveralls

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,10 +7,6 @@ build:
     override:
       - flake8 blocks bin tests examples
       - pep257 blocks bin tests examples --numpy --ignore=D100,D101,D102,D103
-tools:
-  external_code_coverage:
-    runs: 4
-    timeout: 3600
 checks:
     python:
         code_rating: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - |
       conda install -q --yes python=$TRAVIS_PYTHON_VERSION mkl bokeh nose numpy pip coverage six scipy
       pip install -q --no-deps git+git://github.com/Theano/Theano.git # Development version
-      pip install -q nose2 scrutinizer-ocular
+      pip install -q nose2[coverage-plugin] coveralls
 script:
   - |
       python setup.py -q install # Tests setup.py (should also install dill)
@@ -47,4 +47,4 @@ script:
       bokeh-server &> /dev/null &
       coverage run --source=blocks -m nose2.__main__ tests
 after_script:
-  - ocular --data-file ".coverage"
+  - coveralls

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://img.shields.io/scrutinizer/coverage/g/bartvm/blocks/master.svg
-   :target: https://scrutinizer-ci.com/g/bartvm/blocks/code-structure/master
+.. image:: https://img.shields.io/coveralls/bartvm/blocks.svg
+   :target: https://coveralls.io/r/bartvm/blocks
 
 .. image:: https://travis-ci.org/bartvm/blocks.svg?branch=master
    :target: https://travis-ci.org/bartvm/blocks
@@ -9,7 +9,7 @@
 
 .. image:: https://img.shields.io/scrutinizer/g/bartvm/blocks.svg
    :target: https://scrutinizer-ci.com/g/bartvm/blocks/
-   
+
 .. image:: https://img.shields.io/badge/license-MIT-blue.svg
    :target: https://github.com/bartvm/blocks/blob/master/LICENSE
 


### PR DESCRIPTION
Switching back to coveralls for coveage reports, because it's annoying that Scrutinizer needs to wait for Travis to finish. If Travis has a bit of a back log this makes Scrutinizer effectively stop (because it doesn't do parallel builds).