### PR TITLE
WIP: Refactor parallel2

### DIFF
--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -183,11 +183,11 @@ class Distribute(Fork):
     >>> x = tensor.matrix('x')
     >>> y = tensor.matrix('y')
     >>> z = tensor.matrix('z')
-    >>> merge = Distribute(target_names=['x', 'y'], source_name='z',
-    ...                    target_dims=dict(x=2, y=3), source_dim=3,
-    ...                    weights_init=Constant(2))
-    >>> merge.initialize()
-    >>> new_x, new_y = merge.apply(x=x, y=y, z=z)
+    >>> distribute = Distribute(target_names=['x', 'y'], source_name='z',
+    ...                         target_dims=dict(x=2, y=3), source_dim=3,
+    ...                         weights_init=Constant(2))
+    >>> distribute.initialize()
+    >>> new_x, new_y = distribute.apply(x=x, y=y, z=z)
     >>> new_x.eval({x: [[2, 2]], z: [[1, 1, 1]]}) # doctest: +ELLIPSIS
     array([[ 8.,  8.]]...
     >>> new_y.eval({y: [[1, 1, 1]], z: [[1, 1, 1]]}) # doctest: +ELLIPSIS

--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -105,7 +105,7 @@ class Fork(Parallel):
     the copies are applied to the input to produce different outputs.
 
     A typical usecase for this brick is to produce inputs for gates
-    of a gated recurrent bricks, such as
+    of gated recurrent bricks, such as
     :class:`~blocks.bricks.GatedRecurrent`.
 
     >>> from theano import tensor
@@ -127,9 +127,6 @@ class Fork(Parallel):
         Names of the outputs to produce.
     input_dim : int
         The input dimension.
-    prototype : instance of :class:`.Brick`
-        A prototype for the input-to-fork transformations. A copy will be
-        created for every output channel.
 
     Attributes
     ----------
@@ -210,6 +207,10 @@ class Merge(Parallel):
         values are dimensions.
     merged_dim : dict
         The dimension of the merged input.
+
+    Notes
+    -----
+    See :class:`.Initializable` for initialization parameters.
 
     """
     @lazy

--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -165,16 +165,16 @@ class Merge(Parallel):
     """Transform an input and add it to other inputs.
 
     This brick is designed for the following scenario: one has a group of
-    variables and another separate variable, and one needs to somehow
-    merge information from the latter into the former. We call that
-    "to merge a varible into a group of variables", and refer to the separate
-    variable as "the merged input" and to the variables from the group
-    as "the changed inputs".
+    variables and another separate variable, and one needs to somehow merge
+    information from the latter into the former. We call that "to merge a
+    varible into a group of variables", and refer to the separate variable
+    as "the merged input" and to the variables from the group as "the
+    changed inputs".
 
-    Given a prototype brick, a :class:`Parallel` brick makes several
-    copies of it (each with its own parameters). At the application time
-    the copies are applied to the merged input and the transformation
-    results are added to the changed inputs giving the output.
+    Given a prototype brick, a :class:`Parallel` brick makes several copies
+    of it (each with its own parameters). At the application time the
+    copies are applied to the merged input and the transformation results
+    are added to the changed inputs giving the output.
 
     Parameters
     ----------
@@ -201,7 +201,8 @@ class Merge(Parallel):
         self.merged_dim = merged_dim
 
         kwargs.update(self._get_parent_dims())
-        super(Merge, self).__init__(changed_names, prototype=prototype, **kwargs)
+        super(Merge, self).__init__(changed_names, prototype=prototype,
+                                    **kwargs)
 
     def _get_parent_dims(self):
         result = dict()
@@ -211,7 +212,6 @@ class Merge(Parallel):
                                   for name in self.changed_names}
                                  if self.changed_dims else None)
         return result
-
 
     def _push_allocation_config(self):
         self.__dict__.update(self._get_parent_dims())

--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -181,6 +181,21 @@ class Merge(Parallel):
     copies are applied to the merged input and the transformation results
     are added to the changed inputs giving the output.
 
+    >>> from theano import tensor
+    >>> from blocks.initialization import Constant
+    >>> x = tensor.matrix('x')
+    >>> y = tensor.matrix('y')
+    >>> z = tensor.matrix('z')
+    >>> merge = Merge(changed_names=['x', 'y'], merged_name='z',
+    ...               changed_dims=dict(x=2, y=3), merged_dim=3,
+    ...               weights_init=Constant(2))
+    >>> merge.initialize()
+    >>> new_x, new_y = merge.apply(x=x, y=y, z=z)
+    >>> new_x.eval({x: [[2, 2]], z: [[1, 1, 1]]}) # doctest: +ELLIPSIS
+    array([[ 8.,  8.]]...
+    >>> new_y.eval({y: [[1, 1, 1]], z: [[1, 1, 1]]}) # doctest: +ELLIPSIS
+    array([[ 7.,  7.,  7.]]...
+
     Parameters
     ----------
     changed_names : list of str
@@ -210,6 +225,7 @@ class Merge(Parallel):
                                     child_prefix="fork", **kwargs)
 
     def _get_parent_dims(self):
+        """Dimension configuration for the parent brick."""
         result = dict()
         result['input_dims'] = {name: self.merged_dim
                                 for name in self.changed_names}

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -121,7 +121,7 @@ class BaseSequenceGenerator(Initializable):
         if not len(feedback_names) == 1:
             raise ValueError
         self.fork.input_dim = self.readout.get_dim(feedback_names[0])
-        self.fork.fork_dims = {
+        self.fork.output_dims = {
             name: self.transition.get_dim(name)
             for name in self.fork.apply.outputs}
 

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -7,7 +7,7 @@ from theano import tensor
 from blocks.bricks import Initializable, Identity, MLP, Random
 from blocks.bricks.base import application, Brick, lazy
 from blocks.bricks.recurrent import BaseRecurrent
-from blocks.bricks.parallel import Fork, Merge
+from blocks.bricks.parallel import Fork, Distribute
 from blocks.bricks.lookup import LookupTable
 from blocks.bricks.recurrent import recurrent
 from blocks.utils import dict_subset, dict_union
@@ -583,12 +583,12 @@ class AttentionTransition(AbstractAttentionTransition, Initializable):
         self.attention.state_dims = self.transition.get_dims(self.state_names)
         self.attention.sequence_dim = self.transition.get_dim(
             self.attended_name)
-        self.merge.changed_dims = dict_subset(
+        self.merge.target_dims = dict_subset(
             dict_union(
                 self.transition.get_dims(self.sequence_names)),
-            self.merge.changed_names)
-        self.merge.merged_dim = self.attention.get_dim(
-            self.merge.merged_name)
+            self.merge.target_names)
+        self.merge.source_dim = self.attention.get_dim(
+            self.merge.source_name)
 
     @application
     def take_look(self, **kwargs):
@@ -818,7 +818,7 @@ class SequenceGenerator(BaseSequenceGenerator):
 
         fork = Fork(fork_inputs)
         if attention:
-            merge = Merge(fork_inputs, attention.take_look.outputs[0])
+            merge = Distribute(fork_inputs, attention.take_look.outputs[0])
             transition = AttentionTransition(transition, attention, merge,
                                              name="att_trans")
         else:

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -524,7 +524,7 @@ class AttentionTransition(AbstractAttentionTransition, Initializable):
     """Combines an attention mechanism and a recurrent transition.
 
     This brick is assembled from three components: an attention mechanism,
-    a recurrent transition and a merge brick to make the first two work
+    a recurrent transition and a brick to make the first two work
     together.  It is expected that among the contexts of the transition's
     `apply` methods there is one, intended to be attended by the attention
     mechanism, and another one serving as a mask for the first one.
@@ -549,13 +549,13 @@ class AttentionTransition(AbstractAttentionTransition, Initializable):
     Currently lazy-only.
 
     """
-    def __init__(self, transition, attention, merge,
+    def __init__(self, transition, attention, distribute,
                  attended_name=None, attended_mask_name=None,
                  **kwargs):
         super(AttentionTransition, self).__init__(**kwargs)
         self.transition = transition
         self.attention = attention
-        self.merge = merge
+        self.distribute = distribute
 
         self.sequence_names = self.transition.apply.sequences
         self.state_names = self.transition.apply.states
@@ -577,18 +577,18 @@ class AttentionTransition(AbstractAttentionTransition, Initializable):
             name for name in self.glimpse_names
             if name in self.attention.take_look.inputs]
 
-        self.children = [self.transition, self.attention, self.merge]
+        self.children = [self.transition, self.attention, self.distribute]
 
     def _push_allocation_config(self):
         self.attention.state_dims = self.transition.get_dims(self.state_names)
         self.attention.sequence_dim = self.transition.get_dim(
             self.attended_name)
-        self.merge.target_dims = dict_subset(
+        self.distribute.target_dims = dict_subset(
             dict_union(
                 self.transition.get_dims(self.sequence_names)),
-            self.merge.target_names)
-        self.merge.source_dim = self.attention.get_dim(
-            self.merge.source_name)
+            self.distribute.target_names)
+        self.distribute.source_dim = self.attention.get_dim(
+            self.distribute.source_name)
 
     @application
     def take_look(self, **kwargs):
@@ -636,10 +636,10 @@ class AttentionTransition(AbstractAttentionTransition, Initializable):
                                 must_have=False)
         states = dict_subset(kwargs, self.state_names, pop=True)
         glimpses = dict_subset(kwargs, self.glimpse_names, pop=True)
-        sequences.update(self.merge.apply(
+        sequences.update(self.distribute.apply(
             return_dict=True,
             **dict_subset(dict_union(sequences, glimpses),
-                          self.merge.apply.inputs)))
+                          self.distribute.apply.inputs)))
         current_states = self.transition.apply(
             iterate=False, return_list=True,
             **dict_union(sequences, states, kwargs))
@@ -818,8 +818,9 @@ class SequenceGenerator(BaseSequenceGenerator):
 
         fork = Fork(fork_inputs)
         if attention:
-            merge = Distribute(fork_inputs, attention.take_look.outputs[0])
-            transition = AttentionTransition(transition, attention, merge,
+            distribute = Distribute(fork_inputs,
+                                    attention.take_look.outputs[0])
+            transition = AttentionTransition(transition, attention, distribute,
                                              name="att_trans")
         else:
             transition = FakeAttentionTransition(transition,

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -126,7 +126,7 @@ def main(mode, save_path, num_batches, from_dump):
                     weights_init=IsotropicGaussian(0.1),
                     biases_init=Constant(0))
         fork.input_dim = dimension
-        fork.fork_dims = {name: dimension for name in fork.fork_names}
+        fork.output_dims = {name: dimension for name in fork.input_names}
         fork.initialize()
         lookup = LookupTable(readout_dimension, dimension,
                              weights_init=IsotropicGaussian(0.1))

--- a/tests/bricks/test_sequence_generators.py
+++ b/tests/bricks/test_sequence_generators.py
@@ -5,7 +5,7 @@ from theano import tensor
 
 from blocks.bricks import Tanh
 from blocks.bricks.base import application
-from blocks.bricks.parallel import Mixer
+from blocks.bricks.parallel import Merge
 from blocks.bricks.recurrent import Recurrent, GatedRecurrent
 from blocks.bricks.attention import SequenceContentAttention
 from blocks.bricks.sequence_generators import (
@@ -139,11 +139,10 @@ def test_attention_transition():
                                 name="transition")
     attention = SequenceContentAttention(transition.apply.states,
                                          match_dim=inp_dim, name="attention")
-    mixer = Mixer([name for name in transition.apply.sequences
+    merge = Merge([name for name in transition.apply.sequences
                    if name != 'mask'],
-                  attention.take_look.outputs[0],
-                  name="mixer")
-    att_trans = AttentionTransition(transition, attention, mixer,
+                  attention.take_look.outputs[0])
+    att_trans = AttentionTransition(transition, attention, merge,
                                     name="att_trans")
     att_trans.weights_init = IsotropicGaussian(0.01)
     att_trans.biases_init = Constant(0)

--- a/tests/bricks/test_sequence_generators.py
+++ b/tests/bricks/test_sequence_generators.py
@@ -5,7 +5,7 @@ from theano import tensor
 
 from blocks.bricks import Tanh
 from blocks.bricks.base import application
-from blocks.bricks.parallel import Merge
+from blocks.bricks.parallel import Distribute
 from blocks.bricks.recurrent import Recurrent, GatedRecurrent
 from blocks.bricks.attention import SequenceContentAttention
 from blocks.bricks.sequence_generators import (
@@ -139,9 +139,9 @@ def test_attention_transition():
                                 name="transition")
     attention = SequenceContentAttention(transition.apply.states,
                                          match_dim=inp_dim, name="attention")
-    merge = Merge([name for name in transition.apply.sequences
-                   if name != 'mask'],
-                  attention.take_look.outputs[0])
+    merge = Distribute([name for name in transition.apply.sequences
+                        if name != 'mask'],
+                       attention.take_look.outputs[0])
     att_trans = AttentionTransition(transition, attention, merge,
                                     name="att_trans")
     att_trans.weights_init = IsotropicGaussian(0.01)

--- a/tests/bricks/test_sequence_generators.py
+++ b/tests/bricks/test_sequence_generators.py
@@ -139,10 +139,10 @@ def test_attention_transition():
                                 name="transition")
     attention = SequenceContentAttention(transition.apply.states,
                                          match_dim=inp_dim, name="attention")
-    merge = Distribute([name for name in transition.apply.sequences
-                        if name != 'mask'],
-                       attention.take_look.outputs[0])
-    att_trans = AttentionTransition(transition, attention, merge,
+    distribute = Distribute([name for name in transition.apply.sequences
+                             if name != 'mask'],
+                            attention.take_look.outputs[0])
+    att_trans = AttentionTransition(transition, attention, distribute,
                                     name="att_trans")
     att_trans.weights_init = IsotropicGaussian(0.01)
     att_trans.biases_init = Constant(0)


### PR DESCRIPTION
I continue refactoring of `parallel.py`. The most hated `Mixer` became `Merge`, which was a linguistic challenge for me, and I am still not quite satisfied with the current naming scheme. Please tell me if you have better suggestions.

- [x] Doctest for `Merge`
- [x] Change names of the `Parallel`'s children. 
- [ ] Somehow check that this commit does not break the sequence generator

The last item of TODO is quite non-trivial by the way. Unit tests are a nice way to check that simple bricks work, but for proper testing big components like the sequence generator another mechanism is needed. At the company I used to work at people checked outputs of large scripts for this purpose, and those gold-standard output were part of the repo. Guess we also have to go this way. @bartvm, would you mind loading a moderate-sized model to Travis for testing purposes?