### PR TITLE
Split datasets into datasets, streams and iterator

### DIFF
--- a/blocks/datasets/__init__.py
+++ b/blocks/datasets/__init__.py
@@ -1,11 +1,9 @@
 import collections
 from abc import ABCMeta, abstractmethod
 
-import numpy
-import six
-import theano
 from six import add_metaclass
 
+from blocks.datasets.streams import DataStream
 from blocks.utils import LambdaIterator, SequenceIterator
 
 
@@ -266,76 +264,76 @@ class InMemoryDataset(Dataset):
         """
         pass
 
+    @staticmethod
+    def lazy_properties(*lazy_properties):
+        r"""Decorator to assign lazy properties.
 
-def lazy_properties(*lazy_properties):
-    r"""Decorator to assign lazy properties.
+        Used to assign "lazy properties" on :class:`InMemoryDataset`
+        classes.  Please see the documentation there for a discussion on
+        what lazy properties are and why they are needed.
 
-    Used to assign "lazy properties" on :class:`InMemoryDataset` classes.
-    Please see the documentation there for a discussion on what lazy
-    properties are and why they are needed.
+        Parameters
+        ----------
+        \*lazy_properties : strings
+            The names of the attributes that are lazy.
 
-    Parameters
-    ----------
-    \*lazy_properties : strings
-        The names of the attributes that are lazy.
+        Notes
+        -----
+        The pickling behavior of the dataset is only overridden if the
+        dataset does not have a ``__getstate__`` method implemented.
 
-    Notes
-    -----
-    The pickling behavior of the dataset is only overridden if the dataset
-    does not have a ``__getstate__`` method implemented.
+        Examples
+        --------
+        In order to make sure that attributes are not serialized with the
+        dataset, and are lazily reloaded by the
+        :meth:`~InMemoryDataset.load` method after deserialization, use the
+        decorator with the names of the attributes as an argument.
 
-    Examples
-    --------
-    In order to make sure that attributes are not serialized with the
-    dataset, and are lazily reloaded by the :meth:`~InMemoryDataset.load`
-    method after deserialization, use the decorator with the names of the
-    attributes as an argument.
+        >>> @InMemoryDataset.lazy_properties('features', 'targets')
+        ... class TestDataset(InMemoryDataset):
+        ...     def load(self):
+        ...         self.features = range(10 ** 6)
+        ...         self.targets = range(10 ** 6)[::-1]
 
-    >>> @lazy_properties('features', 'targets')
-    ... class TestDataset(InMemoryDataset):
-    ...     def load(self):
-    ...         self.features = range(10 ** 6)
-    ...         self.targets = range(10 ** 6)[::-1]
+        """
+        def lazy_property_factory(lazy_property):
+            """Create properties that perform lazy loading of attributes."""
+            def lazy_property_getter(self):
+                if not hasattr(self, '_' + lazy_property):
+                    self.load()
+                if not hasattr(self, '_' + lazy_property):
+                    raise ValueError("{} wasn't loaded".format(lazy_property))
+                return getattr(self, '_' + lazy_property)
 
-    """
-    def lazy_property_factory(lazy_property):
-        """Create properties that perform lazy loading of attributes."""
-        def lazy_property_getter(self):
-            if not hasattr(self, '_' + lazy_property):
-                self.load()
-            if not hasattr(self, '_' + lazy_property):
-                raise ValueError("{} wasn't loaded".format(lazy_property))
-            return getattr(self, '_' + lazy_property)
+            def lazy_property_setter(self, value):
+                setattr(self, '_' + lazy_property, value)
 
-        def lazy_property_setter(self, value):
-            setattr(self, '_' + lazy_property, value)
+            return lazy_property_getter, lazy_property_setter
 
-        return lazy_property_getter, lazy_property_setter
+        def wrap_dataset(dataset):
+            if not issubclass(dataset, InMemoryDataset):
+                raise ValueError("Only InMemoryDataset supports lazy loading")
 
-    def wrap_dataset(dataset):
-        if not issubclass(dataset, InMemoryDataset):
-            raise ValueError("Only InMemoryDataset supports lazy loading")
+            # Attach the lazy loading properties to the class
+            for lazy_property in lazy_properties:
+                setattr(dataset, lazy_property,
+                        property(*lazy_property_factory(lazy_property)))
 
-        # Attach the lazy loading properties to the class
-        for lazy_property in lazy_properties:
-            setattr(dataset, lazy_property,
-                    property(*lazy_property_factory(lazy_property)))
+            # Delete the values of lazy properties when serializing
+            if not hasattr(dataset, '__getstate__'):
+                def __getstate__(self):
+                    serializable_state = self.__dict__.copy()
+                    for lazy_property in lazy_properties:
+                        attr = serializable_state.get('_' + lazy_property)
+                        # Iterators would lose their state
+                        if isinstance(attr, collections.Iterator):
+                            raise ValueError("Iterators can't be lazy loaded")
+                        serializable_state.pop('_' + lazy_property, None)
+                    return serializable_state
+                setattr(dataset, '__getstate__', __getstate__)
 
-        # Delete the values of lazy properties when serializing
-        if not hasattr(dataset, '__getstate__'):
-            def __getstate__(self):
-                serializable_state = self.__dict__.copy()
-                for lazy_property in lazy_properties:
-                    attr = serializable_state.get('_' + lazy_property)
-                    # Iterators would lose their state
-                    if isinstance(attr, collections.Iterator):
-                        raise ValueError("Iterators can't be lazy loaded")
-                    serializable_state.pop('_' + lazy_property, None)
-                return serializable_state
-            setattr(dataset, '__getstate__', __getstate__)
-
-        return dataset
-    return wrap_dataset
+            return dataset
+        return wrap_dataset
 
 
 class ContainerDataset(Dataset):
@@ -381,443 +379,3 @@ class ContainerDataset(Dataset):
         if state is None or request is not None:
             raise ValueError
         return next(state)
-
-
-@add_metaclass(ABCMeta)
-class AbstractDataStream(object):
-    """A stream of data separated into epochs.
-
-    A data stream is an iterable stream of examples/minibatches. It shares
-    similarities with Python file handles return by the ``open`` method.
-    Data streams can be closed using the :meth:`close` method and reset
-    using :meth:`reset` (similar to ``f.seek(0)``).
-
-    Parameters
-    ----------
-    iteration_scheme : :class:`.IterationScheme`, optional
-        The iteration scheme to use when retrieving data. Note that not all
-        datasets support the same iteration schemes, some datasets require
-        one, and others don't support any. In case when the data stream
-        wraps another data stream, the choice of supported iteration
-        schemes is typically even more limited. Be sure to read the
-        documentation of the dataset or data stream in question.
-
-    Attributes
-    ----------
-    iteration_scheme : :class:`.IterationScheme`
-        The iteration scheme used to retrieve data. Can be ``None`` when
-        not used.
-    sources : tuple of strings
-        The names of the data sources returned by this data stream, as
-        given by the dataset.
-
-    """
-    def __init__(self, iteration_scheme=None):
-        self.iteration_scheme = iteration_scheme
-
-    @abstractmethod
-    def get_data(self, request=None):
-        """Request data from the dataset or the wrapped stream.
-
-        Parameters
-        ----------
-        request : object
-            A request fetched from the `request_iterator`.
-
-        """
-        pass
-
-    @abstractmethod
-    def reset(self):
-        """Reset the data stream."""
-        pass
-
-    @abstractmethod
-    def close(self):
-        """Gracefully close the data stream, e.g. releasing file handles."""
-        pass
-
-    @abstractmethod
-    def next_epoch(self):
-        """Switch the data stream to the next epoch."""
-        pass
-
-    @abstractmethod
-    def get_epoch_iterator(self, as_dict=False):
-        return DataIterator(self, self.iteration_scheme.get_request_iterator()
-                            if self.iteration_scheme else None,
-                            as_dict=as_dict)
-
-    def iterate_epochs(self, as_dict=False):
-        """Allow iteration through all epochs.
-
-        Notes
-        -----
-        This method uses the :meth:`get_epoch_iterator` method to retrieve
-        the :class:`DataIterator` for each epoch. The default
-        implementation of this method resets the state of the data stream
-        so that the new epoch can read the data from the beginning.
-        However, this behavior only works as long as the ``epochs``
-        property is iterated over using e.g. ``for epoch in
-        stream.epochs``. If you create the data iterators in advance (e.g.
-        using ``for i, epoch in zip(range(10), stream.epochs`` in Python 2)
-        you must call the :meth:`reset` method yourself.
-
-        """
-        while True:
-            yield self.get_epoch_iterator(as_dict=as_dict)
-
-
-class DataStream(AbstractDataStream):
-    """A stream of data from a dataset.
-
-    Parameters
-    ----------
-    dataset : instance of :class:`Dataset`
-        The dataset from which the data is fetched.
-
-    """
-    def __init__(self, dataset, **kwargs):
-        super(DataStream, self).__init__(**kwargs)
-        self.dataset = dataset
-        self.data_state = self.dataset.open()
-        self._fresh_state = True
-
-    @property
-    def sources(self):
-        if hasattr(self, '_sources'):
-            return self._sources
-        return self.dataset.sources
-
-    @sources.setter
-    def sources(self, value):
-        self._sources = value
-
-    def close(self):
-        self.data_state = self.dataset.close(self.data_state)
-
-    def reset(self):
-        self.data_state = self.dataset.reset(self.data_state)
-        self._fresh_state = True
-
-    def next_epoch(self):
-        self.data_state = self.dataset.next_epoch(self.data_state)
-
-    def get_data(self, request=None):
-        """Get data from the dataset."""
-        return self.dataset.get_data(self.data_state, request)
-
-    def get_epoch_iterator(self, **kwargs):
-        """Get an epoch iterator for the data stream."""
-        if not self._fresh_state:
-            self.next_epoch()
-        else:
-            self._fresh_state = False
-        return super(DataStream, self).get_epoch_iterator(**kwargs)
-
-
-@add_metaclass(ABCMeta)
-class DataStreamWrapper(AbstractDataStream):
-    """A data stream that wraps another data stream.
-
-    Attributes
-    ----------
-    child_epoch_iterator : iterator type
-        When a new epoch iterator is requested, a new epoch creator is
-        automatically requested from the wrapped data stream and stored in
-        this attribute. Use it to access data from the wrapped data stream
-        by calling ``next(self.child_epoch_iterator)``.
-
-    """
-    def __init__(self, data_stream, **kwargs):
-        super(DataStreamWrapper, self).__init__(**kwargs)
-        self.data_stream = data_stream
-
-    @property
-    def sources(self):
-        if hasattr(self, '_sources'):
-            return self._sources
-        return self.data_stream.sources
-
-    @sources.setter
-    def sources(self, value):
-        self._sources = value
-
-    def close(self):
-        self.data_stream.close()
-
-    def reset(self):
-        self.data_stream.reset()
-
-    def next_epoch(self):
-        self.data_stream.next_epoch()
-
-    def get_epoch_iterator(self, **kwargs):
-        """Get an epoch iterator for the wrapped data set.
-
-        Notes
-        -----
-        This default implementation assumes that the epochs of the wrapped
-        data stream are less or equal in length to the original data
-        stream. Implementations for which this is not true should request
-        new epoch iterators from the child data set when necessary.
-
-        """
-        self.child_epoch_iterator = self.data_stream.get_epoch_iterator()
-        return super(DataStreamWrapper, self).get_epoch_iterator(**kwargs)
-
-
-class DataStreamMapping(DataStreamWrapper):
-    """Applies a mapping to the data of the wrapped data stream.
-
-    Parameters
-    ----------
-    data_stream : instance of :class:`DataStream`
-        The wrapped data stream.
-    mapping : callable
-        The mapping to be applied.
-    add_sources : tuple of str, optional
-        When given, the data produced by the mapping is added to original
-        data under source names `add_sources`.
-
-    """
-    def __init__(self, data_stream, mapping, add_sources=None):
-        super(DataStreamMapping, self).__init__(data_stream)
-        self.mapping = mapping
-        self.add_sources = add_sources
-
-    @property
-    def sources(self):
-        return self.data_stream.sources + (self.add_sources
-                                           if self.add_sources else ())
-
-    def get_data(self, request=None):
-        if request is not None:
-            raise ValueError
-        data = next(self.child_epoch_iterator)
-        image = self.mapping(data)
-        if not self.add_sources:
-            return image
-        return data + image
-
-
-class DataStreamFilter(DataStreamWrapper):
-    """Filters samples that meet a predicate.
-
-    Parameters
-    ----------
-    data_stream : instance of :class:`DataStream`
-        The filtered data stream.
-    predicate : callable
-        Should return ``True`` for the samples to be kept.
-
-    """
-    def __init__(self, data_stream, predicate):
-        super(DataStreamFilter, self).__init__(data_stream)
-        self.predicate = predicate
-
-    def get_data(self, request=None):
-        if request is not None:
-            raise ValueError
-        while True:
-            data = next(self.child_epoch_iterator)
-            if self.predicate(data):
-                return data
-
-
-class CachedDataStream(DataStreamWrapper):
-    """Cache examples when sequentially reading a dataset.
-
-    Given a data stream which reads large chunks of data, this data
-    stream caches these chunks and returns smaller batches from it until
-    exhausted.
-
-    Parameters
-    ----------
-    iteration_scheme : :class:`.IterationScheme`
-        Note that this iteration scheme must return batch sizes (integers),
-        which must necessarily be smaller than the child data stream i.e.
-        the batches returned must be smaller than the cache size.
-
-    Attributes
-    ----------
-    cache : list of lists of objects
-        This attribute holds the cache at any given point. It is a list of
-        the same size as the :attr:`sources` attribute. Each element in
-        this list in its turn a list of examples that are currently in the
-        cache. The cache gets emptied at the start of each epoch, and gets
-        refilled when needed through the :meth:`get_data` method.
-
-    """
-    def __init__(self, data_stream, iteration_scheme):
-        super(CachedDataStream, self).__init__(
-            data_stream, iteration_scheme=iteration_scheme)
-        self.cache = [[] for _ in self.sources]
-
-    def get_data(self, request=None):
-        if request > len(self.cache[0]):
-            self._cache()
-        data = []
-        for i, cache in enumerate(self.cache):
-            data.append(numpy.asarray(cache[:request]))
-            self.cache[i] = cache[request:]
-        return tuple(data)
-
-    def get_epoch_iterator(self, **kwargs):
-        self.cache = [[] for _ in self.sources]
-        return super(CachedDataStream, self).get_epoch_iterator(**kwargs)
-
-    def _cache(self):
-        for cache, data in zip(self.cache, next(self.child_epoch_iterator)):
-            cache.extend(data)
-
-
-class BatchDataStream(DataStreamWrapper):
-    """Creates minibatches from data streams providing single examples.
-
-    Some datasets only return one example at at time e.g. when reading text
-    files a line at a time. This wrapper reads several examples
-    sequentially to turn those into minibatches.
-
-    Parameters
-    ----------
-    data_stream : :class:`AbstractDataStream` instance
-        The data stream to wrap.
-    iteration_scheme : :class:`.BatchSizeScheme` instance
-        The iteration scheme to use; should return integers representing
-        the size of the batch to return.
-    strictness : int, optional
-        How strictly the iterator should adhere to the batch size. By
-        default, the value 0 means that the last batch is returned
-        regardless of its size, so it can be smaller than what is actually
-        requested. At level 1, the last batch is discarded if it is not of
-        the correct size. At the highest strictness level, 2, an error is
-        raised if a batch of the requested size cannot be provided.
-
-    """
-    def __init__(self, data_stream, iteration_scheme, strictness=0):
-        super(BatchDataStream, self).__init__(
-            data_stream, iteration_scheme=iteration_scheme)
-        self.strictness = strictness
-
-    def get_data(self, request=None):
-        """Get data from the dataset."""
-        if request is None:
-            raise ValueError
-        data = [[] for _ in self.sources]
-        for i in range(request):
-            try:
-                for source_data, example in zip(
-                        data, next(self.child_epoch_iterator)):
-                    source_data.append(example)
-            except StopIteration:
-                # If some data has been extracted and `strict` is not set,
-                # we should spit out this data before stopping iteration.
-                if not self.strictness and data[0]:
-                    break
-                elif self.strictness > 1 and data[0]:
-                    raise ValueError
-                raise
-        return tuple(numpy.asarray(source_data) for source_data in data)
-
-
-class PaddingDataStream(DataStreamWrapper):
-    """Adds padding to variable-length sequences.
-
-    When your batches consist of variable-length sequences, use this class
-    to equalize lengths by adding zero-padding. To distinguish between
-    data and padding masks can be produced. For each data source that is
-    masked, a new source will be added. This source will have the name of
-    the original source with the suffix ``_mask`` (e.g. ``features_mask``).
-
-    Elements of incoming batches will be treated as numpy arrays (i.e.
-    using `numpy.asarray`). If they have more than one dimension,
-    all dimensions except length, that is the first one, must be equal.
-
-    Parameters
-    ----------
-    data_stream : :class:`AbstractDataStream` instance
-        The data stream to wrap
-    mask_sources : tuple of strings, optional
-        The sources for which we need to add a mask. If not provided, a
-        mask will be created for all data sources
-
-    """
-    def __init__(self, data_stream, mask_sources=None):
-        super(PaddingDataStream, self).__init__(data_stream)
-        if mask_sources is None:
-            mask_sources = self.data_stream.sources
-        self.mask_sources = mask_sources
-
-    @property
-    def sources(self):
-        sources = []
-        for source in self.data_stream.sources:
-            sources.append(source)
-            if source in self.mask_sources:
-                sources.append(source + '_mask')
-        return tuple(sources)
-
-    def get_data(self, request=None):
-        if request is not None:
-            raise ValueError
-        data = list(next(self.child_epoch_iterator))
-        data_with_masks = []
-        for i, (source, source_data) in enumerate(
-                zip(self.data_stream.sources, data)):
-            if source not in self.mask_sources:
-                data_with_masks.append(source_data)
-                continue
-
-            shapes = [numpy.asarray(sample).shape for sample in source_data]
-            lengths = [shape[0] for shape in shapes]
-            max_sequence_length = max(lengths)
-            rest_shape = shapes[0][1:]
-            if not all([shape[1:] == rest_shape for shape in shapes]):
-                raise ValueError("All dimensions except length must be equal")
-            dtype = numpy.asarray(source_data[0]).dtype
-
-            padded_data = numpy.zeros(
-                (len(source_data), max_sequence_length) + rest_shape,
-                dtype=dtype)
-            for i, sample in enumerate(source_data):
-                padded_data[i, :len(sample)] = sample
-            data_with_masks.append(padded_data)
-
-            mask = numpy.zeros((len(source_data), max_sequence_length),
-                               dtype=theano.config.floatX)
-            for i, sequence_length in enumerate(lengths):
-                mask[i, :sequence_length] = 1
-            data_with_masks.append(mask)
-        return tuple(data_with_masks)
-
-
-class DataIterator(six.Iterator):
-    """An iterator over data, representing a single epoch.
-
-    Parameters
-    ----------
-    data_stream : :class:`DataStream` or :class:`DataStreamWrapper`
-        The data stream over which to iterate.
-    request_iterator : iterator
-        An iterator which returns the request to pass to the data stream
-        for each step.
-
-    """
-    def __init__(self, data_stream, request_iterator=None, as_dict=False):
-        self.data_stream = data_stream
-        self.request_iterator = request_iterator
-        self.as_dict = as_dict
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        if self.request_iterator is not None:
-            data = self.data_stream.get_data(next(self.request_iterator))
-        else:
-            data = self.data_stream.get_data()
-        if self.as_dict:
-            return dict(zip(self.data_stream.sources, data))
-        else:
-            return data

--- a/blocks/datasets/iterator.py
+++ b/blocks/datasets/iterator.py
@@ -1,0 +1,32 @@
+import six
+
+
+class DataIterator(six.Iterator):
+    """An iterator over data, representing a single epoch.
+
+    Parameters
+    ----------
+    data_stream : :class:`DataStream` or :class:`DataStreamWrapper`
+        The data stream over which to iterate.
+    request_iterator : iterator
+        An iterator which returns the request to pass to the data stream
+        for each step.
+
+    """
+    def __init__(self, data_stream, request_iterator=None, as_dict=False):
+        self.data_stream = data_stream
+        self.request_iterator = request_iterator
+        self.as_dict = as_dict
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.request_iterator is not None:
+            data = self.data_stream.get_data(next(self.request_iterator))
+        else:
+            data = self.data_stream.get_data()
+        if self.as_dict:
+            return dict(zip(self.data_stream.sources, data))
+        else:
+            return data

--- a/blocks/datasets/mnist.py
+++ b/blocks/datasets/mnist.py
@@ -6,13 +6,13 @@ import numpy
 import theano
 
 from blocks import config
-from blocks.datasets import InMemoryDataset, lazy_properties
+from blocks.datasets import InMemoryDataset
 from blocks.datasets.schemes import SequentialScheme
 MNIST_IMAGE_MAGIC = 2051
 MNIST_LABEL_MAGIC = 2049
 
 
-@lazy_properties('features', 'targets')
+@InMemoryDataset.lazy_properties('features', 'targets')
 class MNIST(InMemoryDataset):
     u"""The MNIST dataset of handwritten digits.
 

--- a/blocks/datasets/streams.py
+++ b/blocks/datasets/streams.py
@@ -1,0 +1,416 @@
+from abc import ABCMeta, abstractmethod
+
+import numpy
+import theano
+from six import add_metaclass
+
+from blocks.datasets.iterator import DataIterator
+
+
+@add_metaclass(ABCMeta)
+class AbstractDataStream(object):
+    """A stream of data separated into epochs.
+
+    A data stream is an iterable stream of examples/minibatches. It shares
+    similarities with Python file handles return by the ``open`` method.
+    Data streams can be closed using the :meth:`close` method and reset
+    using :meth:`reset` (similar to ``f.seek(0)``).
+
+    Parameters
+    ----------
+    iteration_scheme : :class:`.IterationScheme`, optional
+        The iteration scheme to use when retrieving data. Note that not all
+        datasets support the same iteration schemes, some datasets require
+        one, and others don't support any. In case when the data stream
+        wraps another data stream, the choice of supported iteration
+        schemes is typically even more limited. Be sure to read the
+        documentation of the dataset or data stream in question.
+
+    Attributes
+    ----------
+    iteration_scheme : :class:`.IterationScheme`
+        The iteration scheme used to retrieve data. Can be ``None`` when
+        not used.
+    sources : tuple of strings
+        The names of the data sources returned by this data stream, as
+        given by the dataset.
+
+    """
+    def __init__(self, iteration_scheme=None):
+        self.iteration_scheme = iteration_scheme
+
+    @abstractmethod
+    def get_data(self, request=None):
+        """Request data from the dataset or the wrapped stream.
+
+        Parameters
+        ----------
+        request : object
+            A request fetched from the `request_iterator`.
+
+        """
+        pass
+
+    @abstractmethod
+    def reset(self):
+        """Reset the data stream."""
+        pass
+
+    @abstractmethod
+    def close(self):
+        """Gracefully close the data stream, e.g. releasing file handles."""
+        pass
+
+    @abstractmethod
+    def next_epoch(self):
+        """Switch the data stream to the next epoch."""
+        pass
+
+    @abstractmethod
+    def get_epoch_iterator(self, as_dict=False):
+        return DataIterator(self, self.iteration_scheme.get_request_iterator()
+                            if self.iteration_scheme else None,
+                            as_dict=as_dict)
+
+    def iterate_epochs(self, as_dict=False):
+        """Allow iteration through all epochs.
+
+        Notes
+        -----
+        This method uses the :meth:`get_epoch_iterator` method to retrieve
+        the :class:`DataIterator` for each epoch. The default
+        implementation of this method resets the state of the data stream
+        so that the new epoch can read the data from the beginning.
+        However, this behavior only works as long as the ``epochs``
+        property is iterated over using e.g. ``for epoch in
+        stream.epochs``. If you create the data iterators in advance (e.g.
+        using ``for i, epoch in zip(range(10), stream.epochs`` in Python 2)
+        you must call the :meth:`reset` method yourself.
+
+        """
+        while True:
+            yield self.get_epoch_iterator(as_dict=as_dict)
+
+
+class DataStream(AbstractDataStream):
+    """A stream of data from a dataset.
+
+    Parameters
+    ----------
+    dataset : instance of :class:`Dataset`
+        The dataset from which the data is fetched.
+
+    """
+    def __init__(self, dataset, **kwargs):
+        super(DataStream, self).__init__(**kwargs)
+        self.dataset = dataset
+        self.data_state = self.dataset.open()
+        self._fresh_state = True
+
+    @property
+    def sources(self):
+        if hasattr(self, '_sources'):
+            return self._sources
+        return self.dataset.sources
+
+    @sources.setter
+    def sources(self, value):
+        self._sources = value
+
+    def close(self):
+        self.data_state = self.dataset.close(self.data_state)
+
+    def reset(self):
+        self.data_state = self.dataset.reset(self.data_state)
+        self._fresh_state = True
+
+    def next_epoch(self):
+        self.data_state = self.dataset.next_epoch(self.data_state)
+
+    def get_data(self, request=None):
+        """Get data from the dataset."""
+        return self.dataset.get_data(self.data_state, request)
+
+    def get_epoch_iterator(self, **kwargs):
+        """Get an epoch iterator for the data stream."""
+        if not self._fresh_state:
+            self.next_epoch()
+        else:
+            self._fresh_state = False
+        return super(DataStream, self).get_epoch_iterator(**kwargs)
+
+
+@add_metaclass(ABCMeta)
+class DataStreamWrapper(AbstractDataStream):
+    """A data stream that wraps another data stream.
+
+    Attributes
+    ----------
+    child_epoch_iterator : iterator type
+        When a new epoch iterator is requested, a new epoch creator is
+        automatically requested from the wrapped data stream and stored in
+        this attribute. Use it to access data from the wrapped data stream
+        by calling ``next(self.child_epoch_iterator)``.
+
+    """
+    def __init__(self, data_stream, **kwargs):
+        super(DataStreamWrapper, self).__init__(**kwargs)
+        self.data_stream = data_stream
+
+    @property
+    def sources(self):
+        if hasattr(self, '_sources'):
+            return self._sources
+        return self.data_stream.sources
+
+    @sources.setter
+    def sources(self, value):
+        self._sources = value
+
+    def close(self):
+        self.data_stream.close()
+
+    def reset(self):
+        self.data_stream.reset()
+
+    def next_epoch(self):
+        self.data_stream.next_epoch()
+
+    def get_epoch_iterator(self, **kwargs):
+        """Get an epoch iterator for the wrapped data set.
+
+        Notes
+        -----
+        This default implementation assumes that the epochs of the wrapped
+        data stream are less or equal in length to the original data
+        stream. Implementations for which this is not true should request
+        new epoch iterators from the child data set when necessary.
+
+        """
+        self.child_epoch_iterator = self.data_stream.get_epoch_iterator()
+        return super(DataStreamWrapper, self).get_epoch_iterator(**kwargs)
+
+
+class DataStreamMapping(DataStreamWrapper):
+    """Applies a mapping to the data of the wrapped data stream.
+
+    Parameters
+    ----------
+    data_stream : instance of :class:`DataStream`
+        The wrapped data stream.
+    mapping : callable
+        The mapping to be applied.
+    add_sources : tuple of str, optional
+        When given, the data produced by the mapping is added to original
+        data under source names `add_sources`.
+
+    """
+    def __init__(self, data_stream, mapping, add_sources=None):
+        super(DataStreamMapping, self).__init__(data_stream)
+        self.mapping = mapping
+        self.add_sources = add_sources
+
+    @property
+    def sources(self):
+        return self.data_stream.sources + (self.add_sources
+                                           if self.add_sources else ())
+
+    def get_data(self, request=None):
+        if request is not None:
+            raise ValueError
+        data = next(self.child_epoch_iterator)
+        image = self.mapping(data)
+        if not self.add_sources:
+            return image
+        return data + image
+
+
+class DataStreamFilter(DataStreamWrapper):
+    """Filters samples that meet a predicate.
+
+    Parameters
+    ----------
+    data_stream : instance of :class:`DataStream`
+        The filtered data stream.
+    predicate : callable
+        Should return ``True`` for the samples to be kept.
+
+    """
+    def __init__(self, data_stream, predicate):
+        super(DataStreamFilter, self).__init__(data_stream)
+        self.predicate = predicate
+
+    def get_data(self, request=None):
+        if request is not None:
+            raise ValueError
+        while True:
+            data = next(self.child_epoch_iterator)
+            if self.predicate(data):
+                return data
+
+
+class CachedDataStream(DataStreamWrapper):
+    """Cache examples when sequentially reading a dataset.
+
+    Given a data stream which reads large chunks of data, this data
+    stream caches these chunks and returns smaller batches from it until
+    exhausted.
+
+    Parameters
+    ----------
+    iteration_scheme : :class:`.IterationScheme`
+        Note that this iteration scheme must return batch sizes (integers),
+        which must necessarily be smaller than the child data stream i.e.
+        the batches returned must be smaller than the cache size.
+
+    Attributes
+    ----------
+    cache : list of lists of objects
+        This attribute holds the cache at any given point. It is a list of
+        the same size as the :attr:`sources` attribute. Each element in
+        this list in its turn a list of examples that are currently in the
+        cache. The cache gets emptied at the start of each epoch, and gets
+        refilled when needed through the :meth:`get_data` method.
+
+    """
+    def __init__(self, data_stream, iteration_scheme):
+        super(CachedDataStream, self).__init__(
+            data_stream, iteration_scheme=iteration_scheme)
+        self.cache = [[] for _ in self.sources]
+
+    def get_data(self, request=None):
+        if request > len(self.cache[0]):
+            self._cache()
+        data = []
+        for i, cache in enumerate(self.cache):
+            data.append(numpy.asarray(cache[:request]))
+            self.cache[i] = cache[request:]
+        return tuple(data)
+
+    def get_epoch_iterator(self, **kwargs):
+        self.cache = [[] for _ in self.sources]
+        return super(CachedDataStream, self).get_epoch_iterator(**kwargs)
+
+    def _cache(self):
+        for cache, data in zip(self.cache, next(self.child_epoch_iterator)):
+            cache.extend(data)
+
+
+class BatchDataStream(DataStreamWrapper):
+    """Creates minibatches from data streams providing single examples.
+
+    Some datasets only return one example at at time e.g. when reading text
+    files a line at a time. This wrapper reads several examples
+    sequentially to turn those into minibatches.
+
+    Parameters
+    ----------
+    data_stream : :class:`AbstractDataStream` instance
+        The data stream to wrap.
+    iteration_scheme : :class:`.BatchSizeScheme` instance
+        The iteration scheme to use; should return integers representing
+        the size of the batch to return.
+    strictness : int, optional
+        How strictly the iterator should adhere to the batch size. By
+        default, the value 0 means that the last batch is returned
+        regardless of its size, so it can be smaller than what is actually
+        requested. At level 1, the last batch is discarded if it is not of
+        the correct size. At the highest strictness level, 2, an error is
+        raised if a batch of the requested size cannot be provided.
+
+    """
+    def __init__(self, data_stream, iteration_scheme, strictness=0):
+        super(BatchDataStream, self).__init__(
+            data_stream, iteration_scheme=iteration_scheme)
+        self.strictness = strictness
+
+    def get_data(self, request=None):
+        """Get data from the dataset."""
+        if request is None:
+            raise ValueError
+        data = [[] for _ in self.sources]
+        for i in range(request):
+            try:
+                for source_data, example in zip(
+                        data, next(self.child_epoch_iterator)):
+                    source_data.append(example)
+            except StopIteration:
+                # If some data has been extracted and `strict` is not set,
+                # we should spit out this data before stopping iteration.
+                if not self.strictness and data[0]:
+                    break
+                elif self.strictness > 1 and data[0]:
+                    raise ValueError
+                raise
+        return tuple(numpy.asarray(source_data) for source_data in data)
+
+
+class PaddingDataStream(DataStreamWrapper):
+    """Adds padding to variable-length sequences.
+
+    When your batches consist of variable-length sequences, use this class
+    to equalize lengths by adding zero-padding. To distinguish between
+    data and padding masks can be produced. For each data source that is
+    masked, a new source will be added. This source will have the name of
+    the original source with the suffix ``_mask`` (e.g. ``features_mask``).
+
+    Elements of incoming batches will be treated as numpy arrays (i.e.
+    using `numpy.asarray`). If they have more than one dimension,
+    all dimensions except length, that is the first one, must be equal.
+
+    Parameters
+    ----------
+    data_stream : :class:`AbstractDataStream` instance
+        The data stream to wrap
+    mask_sources : tuple of strings, optional
+        The sources for which we need to add a mask. If not provided, a
+        mask will be created for all data sources
+
+    """
+    def __init__(self, data_stream, mask_sources=None):
+        super(PaddingDataStream, self).__init__(data_stream)
+        if mask_sources is None:
+            mask_sources = self.data_stream.sources
+        self.mask_sources = mask_sources
+
+    @property
+    def sources(self):
+        sources = []
+        for source in self.data_stream.sources:
+            sources.append(source)
+            if source in self.mask_sources:
+                sources.append(source + '_mask')
+        return tuple(sources)
+
+    def get_data(self, request=None):
+        if request is not None:
+            raise ValueError
+        data = list(next(self.child_epoch_iterator))
+        data_with_masks = []
+        for i, (source, source_data) in enumerate(
+                zip(self.data_stream.sources, data)):
+            if source not in self.mask_sources:
+                data_with_masks.append(source_data)
+                continue
+
+            shapes = [numpy.asarray(sample).shape for sample in source_data]
+            lengths = [shape[0] for shape in shapes]
+            max_sequence_length = max(lengths)
+            rest_shape = shapes[0][1:]
+            if not all([shape[1:] == rest_shape for shape in shapes]):
+                raise ValueError("All dimensions except length must be equal")
+            dtype = numpy.asarray(source_data[0]).dtype
+
+            padded_data = numpy.zeros(
+                (len(source_data), max_sequence_length) + rest_shape,
+                dtype=dtype)
+            for i, sample in enumerate(source_data):
+                padded_data[i, :len(sample)] = sample
+            data_with_masks.append(padded_data)
+
+            mask = numpy.zeros((len(source_data), max_sequence_length),
+                               dtype=theano.config.floatX)
+            for i, sequence_length in enumerate(lengths):
+                mask[i, :sequence_length] = 1
+            data_with_masks.append(mask)
+        return tuple(data_with_masks)

--- a/blocks/datasets/text.py
+++ b/blocks/datasets/text.py
@@ -4,7 +4,8 @@ import numpy
 from toolz import sliding_window
 
 from blocks import config
-from blocks.datasets import Dataset, CachedDataStream
+from blocks.datasets import Dataset
+from blocks.datasets.streams import CachedDataStream
 
 
 class TextFileState(object):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,7 +54,7 @@ Quickstart
    >>> from blocks.bricks import MLP, Tanh, Softmax
    >>> from blocks.bricks.cost import CategoricalCrossEntropy, MisclassificationRate
    >>> from blocks.initialization import IsotropicGaussian, Constant
-   >>> from blocks.datasets import DataStream
+   >>> from blocks.datasets.streams import DataStream
    >>> from blocks.datasets.mnist import MNIST
    >>> from blocks.datasets.schemes import SequentialScheme
    >>> from blocks.extensions import FinishAfter, Printing

--- a/docs/plotting.rst
+++ b/docs/plotting.rst
@@ -40,7 +40,8 @@ function :math:`f(x) = x^a` to :math:`f(x) = x^2`.
 We train on a 150 random points in :math:`[0, 1]`.
 
 >>> import numpy
->>> from blocks.datasets import DataStream, ContainerDataset
+>>> from blocks.datasets.streams import DataStream
+>>> from blocks.datasets import ContainerDataset
 >>> sample = theano.tensor.scalar('data')
 >>> data_stream = DataStream(ContainerDataset(
 ...     numpy.random.rand(150).astype(theano.config.floatX)))

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -165,7 +165,7 @@ stream which makes use of a particular iteration scheme. We will use an
 iteration scheme that iterates over our MNIST examples sequentially in batches
 of size 256.
 
->>> from blocks.datasets import DataStream
+>>> from blocks.datasets.streams import DataStream
 >>> from blocks.datasets.schemes import SequentialScheme
 >>> data_stream = DataStream(mnist, iteration_scheme=SequentialScheme(
 ...     num_examples=mnist.num_examples, batch_size=256))

--- a/examples/markov_chain/main.py
+++ b/examples/markov_chain/main.py
@@ -17,7 +17,7 @@ from blocks.bricks.recurrent import GatedRecurrent
 from blocks.bricks.sequence_generators import (
     SequenceGenerator, LinearReadout, SoftmaxEmitter, LookupFeedback)
 from blocks.graph import ComputationGraph
-from blocks.datasets import DataStream
+from blocks.datasets.streams import DataStream
 from blocks.datasets.schemes import ConstantScheme
 from blocks.algorithms import GradientDescent, SteepestDescent
 from blocks.initialization import Orthogonal, IsotropicGaussian, Constant

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -9,7 +9,7 @@ from blocks.algorithms import GradientDescent, SteepestDescent
 from blocks.bricks import MLP, Tanh, Softmax, WEIGHTS
 from blocks.bricks.cost import CategoricalCrossEntropy, MisclassificationRate
 from blocks.initialization import IsotropicGaussian, Constant
-from blocks.datasets import DataStream
+from blocks.datasets.streams import DataStream
 from blocks.datasets.mnist import MNIST
 from blocks.datasets.schemes import SequentialScheme
 from blocks.filter import VariableFilter

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -19,7 +19,7 @@ from blocks.bricks.parallel import Fork
 from blocks.bricks.sequence_generators import (
     SequenceGenerator, LinearReadout, SoftmaxEmitter, LookupFeedback)
 from blocks.graph import ComputationGraph
-from blocks.datasets import (
+from blocks.datasets.streams import (
     DataStreamMapping, BatchDataStream, PaddingDataStream,
     DataStreamFilter)
 from blocks.datasets.text import OneBillionWord

--- a/examples/sqrt.py
+++ b/examples/sqrt.py
@@ -17,8 +17,8 @@ from blocks.algorithms import GradientDescent, SteepestDescent
 from blocks.bricks import MLP, Tanh, Identity
 from blocks.bricks.cost import SquaredError
 from blocks.initialization import IsotropicGaussian, Constant
-from blocks.datasets import (ContainerDataset, BatchDataStream,
-                             DataStreamMapping)
+from blocks.datasets import ContainerDataset
+from blocks.datasets.streams import BatchDataStream, DataStreamMapping
 from blocks.datasets.schemes import ConstantScheme
 from blocks.extensions import FinishAfter, Timing, Printing
 from blocks.extensions.saveload import LoadFromDump, Dump

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -4,10 +4,10 @@ import numpy
 from six.moves import zip
 from nose.tools import assert_raises
 
-from blocks.datasets import (
-    CachedDataStream, ContainerDataset, DataStream,
-    DataStreamMapping, BatchDataStream, PaddingDataStream,
-    DataStreamFilter)
+from blocks.datasets import ContainerDataset
+from blocks.datasets.streams import (
+    CachedDataStream, DataStream, DataStreamMapping, BatchDataStream,
+    PaddingDataStream, DataStreamFilter)
 from blocks.datasets.schemes import BatchSizeScheme, ConstantScheme
 
 

--- a/tests/datasets/test_serialization.py
+++ b/tests/datasets/test_serialization.py
@@ -4,7 +4,7 @@ import tempfile
 import dill
 import numpy
 
-from blocks.datasets import DataStream
+from blocks.datasets.streams import DataStream
 from blocks.datasets.mnist import MNIST
 from blocks.datasets.schemes import SequentialScheme
 


### PR DESCRIPTION
So as part of #218 I started looking into `into` a little bit. It's actually quite nice, although a bit rough around the edges regarding documentation. I don't think that we can really use it though, because of serialization... The framework is quite heavily based around generators and iterators, and even if Dill can pickle parts of it, it loses the locations in files, etc. :(

In the process of refactoring datasets a little bit I did end up splitting up the quite enormous `datasets/__init__.py` into three files: datasets, data streams, and the iterator.