### PR TITLE
Fix typos in tutorial.rst

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -79,7 +79,7 @@ with applying the linear transformations and activations.
 >>> hidden_to_output = Linear(name='hidden_to_output', input_dim=100, output_dim=10)
 >>> y_hat = Softmax().apply(hidden_to_output.apply(h))
 
-Blocks' uses "bricks" to build models. Bricks are parametrized Theano
+Blocks uses "bricks" to build models. Bricks are parametrized Theano
 operations. What this means is that we start by initializing bricks with
 certain parameters e.g. ``input_dim``. After initialization we can apply our
 bricks on Theano variables to build the model we want. We'll talk more about
@@ -101,7 +101,7 @@ function is:
 
 .. math:: l(\mathbf{f}(\mathbf{x}), y) = -\log f(\mathbf{x})_y + \lambda_1\|\mathbf{W}^{(1)}\|^2 + \lambda_2\|\mathbf{W}^{(2)}\|^2
 
-To get the weights from our model, we will use Blocks' annotation futures (read
+To get the weights from our model, we will use Blocks' annotation features (read
 more about them in the :doc:`cg` tutorial).
 
 >>> from blocks.bricks import WEIGHTS
@@ -118,7 +118,7 @@ more about them in the :doc:`cg` tutorial).
    monitor the performance of our model, the progress monitor will know what
    name to report in the logs.
 
-Where we set :math:`\lambda_1 = \lambda_2 = 0.005`. And that's it! We now have
+Here we set :math:`\lambda_1 = \lambda_2 = 0.005`. And that's it! We now have
 the final objective function we want to optimize.
 
 But creating a simple MLP this way is rather cumbersome. In practice, we would
@@ -176,15 +176,15 @@ As our algorithm we will use straightforward SGD with a fixed learning rate.
 >>> algorithm = GradientDescent(cost=cost, step_rule=SteepestDescent(learning_rate=0.1))
 
 During training we will want to monitor the performance of our model on
-separate validation. Let's create a new data stream for that.
+a separate set of examples. Let's create a new data stream for that.
 
 >>> mnist_test = MNIST("test")
 >>> data_stream_test = DataStream(mnist_test, iteration_scheme=SequentialScheme(
 ...     num_examples=mnist_test.num_examples, batch_size=1024))
 
 In order to monitor our performance on this data stream during training, we need
-to use one of Blocks' extensions. In particular, we need to use the
-:class:`.DataStreamMonitoring` extension.
+to use one of Blocks' extensions, namely the :class:`.DataStreamMonitoring`
+extension.
 
 >>> from blocks.extensions.monitoring import DataStreamMonitoring
 >>> monitor = DataStreamMonitoring(


### PR DESCRIPTION
In addition to the proposed fixes, I think the paragraph containing the sentence `MNIST defines two data sources: 'features' and 'targets'` could be expanded a little to make it clearer. The phrasing makes it unclear whether MNIST refers to the actual data or to the dataset class.

A quick explanation of what's a data source and why the variable names must match the data source of a given dataset would help.

I can come up with something and make it part of this pull request if you'd like, or I can leave that for a future pull request.