### PR TITLE
Fix installation instructions for developers

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -59,12 +59,12 @@ Development
 
 If you want to work on Blocks' development, your first step is to `fork Blocks
 on GitHub`_. You will now want to install your fork of Blocks in editable mode.
-To install in your home directory, use the following command, replacing ``user``
+To install in your home directory, use the following command, replacing ``USER``
 with your own GitHub user name:
 
 .. code-block:: bash
 
-   $ pip install --upgrade -e git+git://github.com/user/blocks.git#egg=blocks[test,plot,docs] --src=$HOME
+   $ pip install --upgrade -e git+git@github.com:USER/blocks.git#egg=blocks[test,plot,docs] --src=$HOME
 
 As with the usual installation, you can use ``--user`` or ``--no-deps`` if you
 need to. You can now make changes in the ``blocks`` directory created by pip,

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -64,7 +64,7 @@ with your own GitHub user name:
 
 .. code-block:: bash
 
-   $ pip install --upgrade -e git+git://github.com/user/blocks.git#egg=blocks[tests] --src=$HOME
+   $ pip install --upgrade -e git+git://github.com/user/blocks.git#egg=blocks[test,plot,docs] --src=$HOME
 
 As with the usual installation, you can use ``--user`` or ``--no-deps`` if you
 need to. You can now make changes in the ``blocks`` directory created by pip,


### PR DESCRIPTION
There are two fixes. Can take both or only the first one
- Fix required_extra that fixes the command so that it doesn't fail anymore
- Another, that changes the default protocol to ssh (requiring user to have setup their ssh key on github) and allowing pushing. Also performs minor style change to highlight which part of the command is supposed to be changed.

I opened issue #241 for the former.