### PR TITLE
Move minus to the GradientDescent

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -154,16 +154,18 @@ class GradientDescent(DifferentiableCostMinimizer):
             for param in params:
                 param -= steps[param]
 
+    Note, that the step is _subtracted, not added_! This is done in order
+    to make step rule chaining possible.
+
     Parameters
     ----------
     step_rule : instance of :class:`StepRule`, optional
         An object encapsulating most of the algorithm's logic. Its
         `compute_steps` method is called to get Theano expression for
-        steps. Note, that the step rule
-        might have a state, e.g. to remember a weighted sum of gradients
-        from previous steps like it is done in gradient descent with
-        momentum. If ``None``, an instance of :class:`SteepestDescent` is
-        created.
+        steps.  Note, that the step rule might have a state, e.g. to
+        remember a weighted sum of gradients from previous steps like it is
+        done in gradient descent with momentum. If ``None``, an instance of
+        :class:`SteepestDescent` is created.
     gradients : dict, optional
         A dictionary mapping a parameter to an expression for the cost's
         gradient with respect to the parameter. If ``None``, the gradient
@@ -210,8 +212,8 @@ class GradientDescent(DifferentiableCostMinimizer):
         if not set(batch.keys()) == set([v.name for v in self.inputs]):
             raise ValueError("mismatch of variable names and data sources" +
                              variable_mismatch_error.format(
-                                sources=batch.keys(),
-                                variables=[v.name for v in self.inputs]))
+                                 sources=batch.keys(),
+                                 variables=[v.name for v in self.inputs]))
         ordered_batch = [batch[v.name] for v in self.inputs]
         self._function(*ordered_batch)
 
@@ -298,7 +300,7 @@ class SteepestDescent(StepRule):
 
 
 class Momentum(StepRule):
-    """Accumulates the step with exponential discount.
+    """Accumulates gradients with exponential discount.
 
     Parameters
     ----------

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -152,7 +152,7 @@ class GradientDescent(DifferentiableCostMinimizer):
         for batch in data:
             steps = step_rule.compute_steps(params, gradients_wr_params)
             for param in params:
-                param += steps[param]
+                param -= steps[param]
 
     Parameters
     ----------
@@ -201,7 +201,7 @@ class GradientDescent(DifferentiableCostMinimizer):
         # the parameters were given. Keep it like that to ensure
         # reproducibility.
         for param in self.params:
-            all_updates.append((param, param + self.steps[param]))
+            all_updates.append((param, param - self.steps[param]))
         all_updates += self.step_rule_updates
         self._function = theano.function(self.inputs, [], updates=all_updates)
         logger.info("The training algorithm is initialized")
@@ -276,7 +276,7 @@ class StepRule(object):
 
 
 class SteepestDescent(StepRule):
-    """A step in the direction opposite to the gradient.
+    """A step in the direction proportional to the gradient.
 
     Parameters
     ----------
@@ -294,7 +294,7 @@ class SteepestDescent(StepRule):
         self.learning_rate = shared_floatx(learning_rate)
 
     def compute_step(self, param, gradient):
-        return -self.learning_rate * gradient, []
+        return self.learning_rate * gradient, []
 
 
 class Momentum(StepRule):
@@ -351,7 +351,7 @@ class AdaDelta(StepRule):
 
         rms_delta_x_tm1 = tensor.sqrt(mean_square_delta_x_tm1 + self.epsilon)
         rms_grad_t = tensor.sqrt(mean_square_grad_t + self.epsilon)
-        delta_x_t = - rms_delta_x_tm1 / rms_grad_t * gradient
+        delta_x_t = rms_delta_x_tm1 / rms_grad_t * gradient
 
         mean_square_delta_x_t = (
             self.decay_rate * mean_square_delta_x_tm1 +

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -40,9 +40,9 @@ def test_adadelta():
     steps, updates = AdaDelta(decay_rate=0.5, epsilon=1e-7).compute_steps(
         OrderedDict([(a, tensor.grad(cost, a))]))
     f = theano.function([], [steps[a]], updates=updates)
-    assert_allclose(f()[0], [-0.00044721, -0.00044721], rtol=1e-5)
-    assert_allclose(f()[0], [-0.0005164, -0.0005164], rtol=1e-5)
-    assert_allclose(f()[0], [-0.00056904, -0.00056904], rtol=1e-5)
+    assert_allclose(f()[0], [0.00044721, 0.00044721], rtol=1e-5)
+    assert_allclose(f()[0], [0.0005164, 0.0005164], rtol=1e-5)
+    assert_allclose(f()[0], [0.00056904, 0.00056904], rtol=1e-5)
 
 
 def test_adadelta_decay_rate_sanity_check():
@@ -67,8 +67,8 @@ def test_composite_rule():
     rule = CompositeRule([GradientClipping(4), SteepestDescent(0.1)])
     gradients = {0: shared_floatx(3.0), 1: shared_floatx(4.0)}
     result, _ = rule.compute_steps(gradients)
-    assert_allclose(result[0].eval(), -12 / 50.0)
-    assert_allclose(result[1].eval(), -16 / 50.0)
+    assert_allclose(result[0].eval(), 12 / 50.0)
+    assert_allclose(result[1].eval(), 16 / 50.0)
 
     class RuleWithUpdates(StepRule):
         def __init__(self, updates):


### PR DESCRIPTION
Inspired by the concerns of @vdumoulin from #240, I propose the following modification: in step rules instead of the something to be added to the parameters return something to be subtracted. The reason that to conform with semantic of "the step to be added" every step rule should have a multiplication by -1, but this would make chaining impossible. 

I suggest to keep calling the subtracted entity a "step", because it is just  very convenient. If we call it something like `antistep`, that would be more to the point but less readable.