### PR TITLE
Implement RMSProp as a StepRule

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -406,6 +406,11 @@ class RMSPropChainable(StepRule):
     step rule, _e.g._ :class:`SteepestDescent`. For an
     all-batteries-included experience, look at :class:`RMSProp`.
 
+    In general, this step rule should be used _before_ other step rules,
+    because it has normalization properties that may undo their work.
+    For instance, it should be applied first when used in conjunction
+    with :class:`SteepestDescent`.
+
     For more information, see [RMSProp]_.
 
     .. [RMSProp] Geoff Hinton, *Neural Networks for Machine Learning*,

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -277,6 +277,28 @@ class StepRule(object):
         return steps, updates
 
 
+class CompositeRule(StepRule):
+    """Chains several step rules.
+
+    Parameters
+    ----------
+    components : list of :class:`StepRule`
+        The learning rules to be chained. The rules will be applied in the
+        order as given.
+
+    """
+    def __init__(self, components):
+        self.components = components
+
+    def compute_steps(self, gradients):
+        result = gradients
+        updates = []
+        for rule in self.components:
+            result, more_updates = rule.compute_steps(result)
+            updates += more_updates
+        return result, updates
+
+
 class SteepestDescent(StepRule):
     """A step in the direction proportional to the gradient.
 
@@ -429,25 +451,3 @@ class GradientClipping(StepRule):
             (param, gradient * multiplier)
             for param, gradient in gradients.items())
         return steps, []
-
-
-class CompositeRule(StepRule):
-    """Chains several step rules.
-
-    Parameters
-    ----------
-    components : list of :class:`StepRule`
-        The learning rules to be chained. The rules will be applied in the
-        order as given.
-
-    """
-    def __init__(self, components):
-        self.components = components
-
-    def compute_steps(self, gradients):
-        result = gradients
-        updates = []
-        for rule in self.components:
-            result, more_updates = rule.compute_steps(result)
-            updates += more_updates
-        return result, updates

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -420,11 +420,11 @@ class RMSPropBase(StepRule):
     def compute_step(self, param, gradient):
         mean_square_grad_tm1 = shared_floatx(param.get_value() * 0.)
         mean_square_grad_t = (self.decay_rate * mean_square_grad_tm1 +
-                              (1 - self.decay_rate) * tensor.sqr(param))
+                              (1 - self.decay_rate) * tensor.sqr(gradient))
         rms_grad_t = tensor.maximum(
             tensor.sqrt(mean_square_grad_t), self.epsilon)
         step = gradient / rms_grad_t
-        updates = [(mean_square_grad_t, rms_grad_t)]
+        updates = [(mean_square_grad_tm1, mean_square_grad_t)]
         return step, updates
 
 

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -388,7 +388,7 @@ class AdaDelta(StepRule):
         return step, updates
 
 
-class RMSPropBase(StepRule):
+class RMSPropChainable(StepRule):
     """Scales the step size by a running average of the recent gradient norms.
 
     Parameters
@@ -459,7 +459,7 @@ class RMSProp(CompositeRule):
     def __init__(self, learning_rate=1.0, decay_rate=0.9, max_scaling=1e5):
         self.components = [
             SteepestDescent(learning_rate=learning_rate),
-            RMSPropBase(decay_rate=decay_rate, max_scaling=max_scaling)]
+            RMSPropChainable(decay_rate=decay_rate, max_scaling=max_scaling)]
 
 
 class GradientClipping(StepRule):

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -419,9 +419,10 @@ class RMSPropBase(StepRule):
 
     def compute_step(self, param, gradient):
         mean_square_grad_tm1 = shared_floatx(param.get_value() * 0.)
-        mean_squared_grad_t = (self.decay_rate * mean_square_grad_tm1 +
-                               (1 - self.decay_rate) * T.sqr(param))
-        rms_grad_t = T.maximum(T.sqrt(mean_squared_grad_t), self.epsilon)
+        mean_square_grad_t = (self.decay_rate * mean_square_grad_tm1 +
+                              (1 - self.decay_rate) * tensor.sqr(param))
+        rms_grad_t = tensor.maximum(
+            tensor.sqrt(mean_square_grad_t), self.epsilon)
         step = gradient / rms_grad_t
         updates = [(mean_square_grad_t, rms_grad_t)]
         return step, updates

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -388,7 +388,7 @@ class AdaDelta(StepRule):
         return step, updates
 
 
-class RMSPropChainable(StepRule):
+class BasicRMSProp(StepRule):
     """Scales the step size by a running average of the recent gradient norms.
 
     Parameters
@@ -463,7 +463,7 @@ class RMSProp(CompositeRule):
     """
     def __init__(self, learning_rate=1.0, decay_rate=0.9, max_scaling=1e5):
         self.components = [
-            RMSPropChainable(decay_rate=decay_rate, max_scaling=max_scaling),
+            BasicRMSProp(decay_rate=decay_rate, max_scaling=max_scaling),
             SteepestDescent(learning_rate=learning_rate)]
 
 

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -406,6 +406,12 @@ class RMSPropBase(StepRule):
     step rule, _e.g._ :class:`SteepestDescent`. For an
     all-batteries-included experience, look at :class:`RMSProp`.
 
+    For more information, see [RMSProp]_.
+
+    .. [RMSProp] Geoff Hinton, *Neural Networks for Machine Learning*,
+       lecture 6a, <http://www.cs.toronto.edu/~tijmen/csc321/slides/
+       lecture_slides_lec6.pdf>
+
     """
     def __init__(self, decay_rate=0.9, max_scaling=1e5):
         self.decay_rate = shared_floatx(decay_rate)
@@ -419,6 +425,36 @@ class RMSPropBase(StepRule):
         step = gradient / rms_grad_t
         updates = [(mean_square_grad_t, rms_grad_t)]
         return step, updates
+
+
+class RMSProp(CompositeRule):
+    """Scales the step size by a running average of the recent gradient norms.
+
+    Parameters
+    ----------
+    learning_rate : float, optional
+        The learning rate by which the gradient is multiplied to produce
+        the descent step. Defaults to 1.
+    decay_rate : float, optional
+        How fast the running average decays (lower is faster).
+        Defaults to 0.9.
+    max_scaling : float, optional
+        Maximum scaling of the step size, in case the running average is
+        really small. Defaults to 1e5.
+
+    Notes
+    -----
+    For more information, see [RMSProp]_.
+
+    .. [RMSProp] Geoff Hinton, *Neural Networks for Machine Learning*,
+       lecture 6a, <http://www.cs.toronto.edu/~tijmen/csc321/slides/
+       lecture_slides_lec6.pdf>
+
+    """
+    def __init__(self, learning_rate=1.0, decay_rate=0.9, max_scaling=1e5):
+        self.components = [
+            SteepestDescent(learning_rate=learning_rate),
+            RMSPropBase(decay_rate=decay_rate, max_scaling=max_scaling)]
 
 
 class GradientClipping(StepRule):

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -458,8 +458,8 @@ class RMSProp(CompositeRule):
     """
     def __init__(self, learning_rate=1.0, decay_rate=0.9, max_scaling=1e5):
         self.components = [
-            SteepestDescent(learning_rate=learning_rate),
-            RMSPropChainable(decay_rate=decay_rate, max_scaling=max_scaling)]
+            RMSPropChainable(decay_rate=decay_rate, max_scaling=max_scaling),
+            SteepestDescent(learning_rate=learning_rate)]
 
 
 class GradientClipping(StepRule):

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -394,11 +394,11 @@ class RMSPropBase(StepRule):
     Parameters
     ----------
     decay_rate : float, optional
-        How fast the running average decays (lower is faster).
-        Defaults to 0.9.
+        How fast the running average decays, value in [0, 1]
+        (lower is faster).  Defaults to 0.9.
     max_scaling : float, optional
         Maximum scaling of the step size, in case the running average is
-        really small. Defaults to 1e5.
+        really small. Needs to be greater than 0. Defaults to 1e5.
 
     Notes
     -----
@@ -414,6 +414,10 @@ class RMSPropBase(StepRule):
 
     """
     def __init__(self, decay_rate=0.9, max_scaling=1e5):
+        if not 0.0 <= decay_rate <= 1.0:
+            raise ValueError("decay rate needs to be in [0, 1]")
+        if max_scaling <= 0:
+            raise ValueError("max. scaling needs to be greater than 0")
         self.decay_rate = shared_floatx(decay_rate)
         self.epsilon = 1. / max_scaling
 

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -91,11 +91,11 @@ def test_rmsprop():
     steps, updates = step_rule.compute_steps(
         OrderedDict([(a, tensor.grad(cost, a))]))
     f = theano.function([], [steps[a]], updates=updates)
-    assert_allclose(f()[0], [-0.141421356, -0.141421356])
+    assert_allclose(f()[0], [0.141421356, 0.141421356])
     a.set_value([2, 3])
-    assert_allclose(f()[0], [-0.09701425, -0.102899151])
+    assert_allclose(f()[0], [0.09701425, 0.102899151])
     a.set_value([1, 1.5])
-    assert_allclose(f()[0], [-0.06172134, -0.064699664])
+    assert_allclose(f()[0], [0.06172134, 0.064699664])
 
 
 def test_gradient_clipping():

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -51,7 +51,7 @@ def test_adadelta_decay_rate_sanity_check():
     assert_raises(ValueError, AdaDelta, 2.0)
 
 
-def test_rmspropbase():
+def test_rmspropchainable():
     a = shared_floatx([3, 4])
     cost = (a ** 2).sum()
     step_rule = RMSPropChainable(decay_rate=0.5, max_scaling=1e5)
@@ -65,7 +65,7 @@ def test_rmspropbase():
     assert_allclose(f()[0], [0.6172134, 0.64699664])
 
 
-def test_rmspropbase_max_scaling():
+def test_rmspropchainable_max_scaling():
     a = shared_floatx([1e-6, 1e-6])
     cost = (a ** 2).sum()
     step_rule = RMSPropChainable(decay_rate=0.5, max_scaling=1e5)
@@ -75,7 +75,7 @@ def test_rmspropbase_max_scaling():
     assert_allclose(f()[0], [0.2, 0.2])
 
 
-def test_rmspropbase_decay_rate_sanity_check():
+def test_rmspropchainable_decay_rate_sanity_check():
     assert_raises(ValueError, RMSPropChainable, -1.0)
     assert_raises(ValueError, RMSPropChainable, 2.0)
 

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -7,7 +7,7 @@ from theano import tensor
 
 from blocks.algorithms import (GradientDescent, GradientClipping,
                                CompositeRule, SteepestDescent,
-                               StepRule, Momentum, AdaDelta, RMSPropChainable,
+                               StepRule, Momentum, AdaDelta, BasicRMSProp,
                                RMSProp)
 from blocks.utils import shared_floatx
 
@@ -51,10 +51,10 @@ def test_adadelta_decay_rate_sanity_check():
     assert_raises(ValueError, AdaDelta, 2.0)
 
 
-def test_rmspropchainable():
+def test_basicrmsprop():
     a = shared_floatx([3, 4])
     cost = (a ** 2).sum()
-    step_rule = RMSPropChainable(decay_rate=0.5, max_scaling=1e5)
+    step_rule = BasicRMSProp(decay_rate=0.5, max_scaling=1e5)
     steps, updates = step_rule.compute_steps(
         OrderedDict([(a, tensor.grad(cost, a))]))
     f = theano.function([], [steps[a]], updates=updates)
@@ -65,23 +65,23 @@ def test_rmspropchainable():
     assert_allclose(f()[0], [0.6172134, 0.64699664])
 
 
-def test_rmspropchainable_max_scaling():
+def test_basicrmsprop_max_scaling():
     a = shared_floatx([1e-6, 1e-6])
     cost = (a ** 2).sum()
-    step_rule = RMSPropChainable(decay_rate=0.5, max_scaling=1e5)
+    step_rule = BasicRMSProp(decay_rate=0.5, max_scaling=1e5)
     steps, updates = step_rule.compute_steps(
         OrderedDict([(a, tensor.grad(cost, a))]))
     f = theano.function([], [steps[a]], updates=updates)
     assert_allclose(f()[0], [0.2, 0.2])
 
 
-def test_rmspropchainable_decay_rate_sanity_check():
-    assert_raises(ValueError, RMSPropChainable, -1.0)
-    assert_raises(ValueError, RMSPropChainable, 2.0)
+def test_basicrmsprop_decay_rate_sanity_check():
+    assert_raises(ValueError, BasicRMSProp, -1.0)
+    assert_raises(ValueError, BasicRMSProp, 2.0)
 
 
-def test_rmspropchainable_max_scaling_sanity_check():
-    assert_raises(ValueError, RMSPropChainable, 0.5, -1.0)
+def test_basicrmsprop_max_scaling_sanity_check():
+    assert_raises(ValueError, BasicRMSProp, 0.5, -1.0)
 
 
 def test_rmsprop():

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -80,8 +80,22 @@ def test_rmspropchainable_decay_rate_sanity_check():
     assert_raises(ValueError, RMSPropChainable, 2.0)
 
 
-def test_rmspropbase_max_scaling_sanity_check():
+def test_rmspropchainable_max_scaling_sanity_check():
     assert_raises(ValueError, RMSPropChainable, 0.5, -1.0)
+
+
+def test_rmsprop():
+    a = shared_floatx([3, 4])
+    cost = (a ** 2).sum()
+    step_rule = RMSProp(learning_rate=0.1, decay_rate=0.5, max_scaling=1e5)
+    steps, updates = step_rule.compute_steps(
+        OrderedDict([(a, tensor.grad(cost, a))]))
+    f = theano.function([], [steps[a]], updates=updates)
+    assert_allclose(f()[0], [-0.141421356, -0.141421356])
+    a.set_value([2, 3])
+    assert_allclose(f()[0], [-0.09701425, -0.102899151])
+    a.set_value([1, 1.5])
+    assert_allclose(f()[0], [-0.06172134, -0.064699664])
 
 
 def test_gradient_clipping():


### PR DESCRIPTION
There are two new classes introduced: `RMSPropChainable` and `RMSProp`.

The former is implemented in a way that allows it to chain step rules, much like `Momentum` is implemented right now, while the latter wraps `RMSPropChainable` and `SteepestDescent` to produce a step rule that corresponds to what users would expect out of the box.

The same principle could also be applied to `Momentum` in order to make things a bit more natural while retaining modularity.