### PR TITLE
Add logging configuration to scripts

### DIFF
--- a/bin/blocks-continue
+++ b/bin/blocks-continue
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
+import logging
 from argparse import ArgumentParser
 
 from blocks.scripts import continue_training
 
 if __name__ == "__main__":
+    logging.basicConfig()
+
     parser = ArgumentParser("Continues your pickled main loop")
     parser.add_argument(
         "path", help="A path to a file with a pickled main loop")

--- a/bin/blocks-dump
+++ b/bin/blocks-dump
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
+import logging
 from argparse import ArgumentParser
 
 from blocks.scripts import dump
 
 if __name__ == "__main__":
+    logging.basicConfig()
+
     parser = ArgumentParser(
         "Dumps your pickled main loop. Dumps are a cross-platform way of"
         " sharing results of your experiments orthogonal to the standard"


### PR DESCRIPTION
In Python 2 `basicConfig` is not triggered when the first `logger.debug/error/info` call is done, but instead "No handlers could be found for logger" is printed. So logging configuration has to be in the beginning of all our scripts.