### PR TITLE
When supplying GradientDescent with gradients, they implicitly define which parameters to update

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -182,7 +182,9 @@ class GradientDescent(DifferentiableCostMinimizer):
     def __init__(self, step_rule=None, gradients=None, **kwargs):
         super(GradientDescent, self).__init__(**kwargs)
         self.gradients = gradients
-        if not self.gradients:
+        if self.gradients:
+            self.params = gradients.keys()
+        else:
             logger.info("Taking the cost gradient")
             self.gradients = dict(
                 zip(self.params, tensor.grad(self.cost, self.params)))

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -180,10 +180,9 @@ class GradientDescent(DifferentiableCostMinimizer):
 
     """
     def __init__(self, step_rule=None, gradients=None, **kwargs):
-        if gradients and 'params' not in kwargs:
-            super(GradientDescent, self).__init__(params=gradients.keys(), **kwargs)
-        else:
-            super(GradientDescent, self).__init__(**kwargs)
+        if gradients:
+            kwargs.setdefault("params", gradients.keys())
+        super(GradientDescent, self).__init__(**kwargs)
 
         self.gradients = gradients
         if not self.gradients:

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -180,11 +180,13 @@ class GradientDescent(DifferentiableCostMinimizer):
 
     """
     def __init__(self, step_rule=None, gradients=None, **kwargs):
-        super(GradientDescent, self).__init__(**kwargs)
-        self.gradients = gradients
-        if self.gradients:
-            self.params = gradients.keys()
+        if gradients and 'params' not in kwargs:
+            super(GradientDescent, self).__init__(params=gradients.keys(), **kwargs)
         else:
+            super(GradientDescent, self).__init__(**kwargs)
+
+        self.gradients = gradients
+        if not self.gradients:
             logger.info("Taking the cost gradient")
             self.gradients = dict(
                 zip(self.params, tensor.grad(self.cost, self.params)))

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -23,19 +23,20 @@ def test_gradient_descent():
     algorithm.process_batch(dict())
     assert_allclose(W.get_value(), -0.5 * W_start_value)
 
+
 def test_gradient_descent_with_gradients():
     W = shared_floatx(numpy.array([[1, 2], [3, 4]]))
     W_start_value = W.get_value()
     cost = tensor.sum(W ** 2)
     gradients = OrderedDict()
     gradients[W] = tensor.grad(cost, W)
-    
 
     algorithm = GradientDescent(cost=cost, gradients=gradients)
     algorithm.step_rule.learning_rate.set_value(0.75)
     algorithm.initialize()
     algorithm.process_batch(dict())
     assert_allclose(W.get_value(), -0.5 * W_start_value)
+
 
 def test_momentum():
     a = shared_floatx([3, 4])

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -23,6 +23,19 @@ def test_gradient_descent():
     algorithm.process_batch(dict())
     assert_allclose(W.get_value(), -0.5 * W_start_value)
 
+def test_gradient_descent_with_gradients():
+    W = shared_floatx(numpy.array([[1, 2], [3, 4]]))
+    W_start_value = W.get_value()
+    cost = tensor.sum(W ** 2)
+    gradients = OrderedDict()
+    gradients[W] = tensor.grad(cost, W)
+    
+
+    algorithm = GradientDescent(cost=cost, gradients=gradients)
+    algorithm.step_rule.learning_rate.set_value(0.75)
+    algorithm.initialize()
+    algorithm.process_batch(dict())
+    assert_allclose(W.get_value(), -0.5 * W_start_value)
 
 def test_momentum():
     a = shared_floatx([3, 4])


### PR DESCRIPTION
Currently the 'params' attribute of DifferentiableCostMinimizer is always initialized to contain all shared variables of the cost-graph; even when the user supplies an explicit gradients-dict to GradientDescent. 

1) I guess we can trust the user and automatically set it to gradients.keys()?
2) I wonder whether we should guard GradientDescent.gradients with a property/setter?
