### PR TITLE
Naming of Linear and MLP parameters according to the Brick name

### DIFF
--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -503,7 +503,11 @@ class MLP(Sequence, Initializable, Feedforward):
     def __init__(self, activations, dims, **kwargs):
         self.activations = activations
 
-        self.linear_transformations = [Linear(name='linear_{}'.format(i))
+        # Another solution duplicates code from Brick and initializes Linears
+        # straight away with right name
+        # self.name = kwargs.get('name', self.__class__.__name__.lower())
+
+        self.linear_transformations = [Linear()
                                        for i in range(len(activations))]
         # Interleave the transformations and activations
         application_methods = [brick.apply for brick in interleave(
@@ -512,6 +516,8 @@ class MLP(Sequence, Initializable, Feedforward):
             dims = [None] * (len(activations) + 1)
         self.dims = dims
         super(MLP, self).__init__(application_methods, **kwargs)
+        for i, brick in enumerate(self.linear_transformations):
+            brick.name = '{}_l{}'.format(self.name, i)
 
     @property
     def input_dim(self):

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -206,15 +206,16 @@ class Linear(Initializable, Feedforward):
         self.output_dim = output_dim
 
     def _allocate(self):
-        W = shared_floatx_zeros((self.input_dim, self.output_dim), name='W')
+        W = shared_floatx_zeros((self.input_dim, self.output_dim),
+                                name=self.name + '_W')
         add_role(W, WEIGHTS)
         self.params.append(W)
-        self.add_auxiliary_variable(W.norm(2), name='W_norm')
+        self.add_auxiliary_variable(W.norm(2), name=self.name + '_W_norm')
         if self.use_bias:
-            b = shared_floatx_zeros((self.output_dim,), name='b')
+            b = shared_floatx_zeros((self.output_dim,), name=self.name + '_b')
             add_role(b, BIASES)
             self.params.append(b)
-            self.add_auxiliary_variable(b.norm(2), name='b_norm')
+            self.add_auxiliary_variable(b.norm(2), name=self.name + '_b_norm')
 
     def _initialize(self):
         if self.use_bias:


### PR DESCRIPTION
If I create an MLP, it will name all the weights "W" and all the biases "b". Unique names would be nice based on the brick name. 

For instance, consider the following autoencoder:

```python
    x = tensor.matrix('features')
    enc = MLP([Rectifier(), Rectifier()], [784, 1000, 2000], name='enc')
    dec = MLP([Rectifier(), None], [2000, 1000, 784], name='dec')
    cg = ComputationGraph(dec.apply(enc.apply(x)))
    print VariableFilter(roles=[PARAMETER])(cg.variables)
```
```[b, b, b, b, W, W, W, W]```

One solution is to use ```ComputationGraph``` and its tools to rename them according to the owning ```Brick``` at query time if user wants. There's also ```var.tag.name``` which role is unclear and not documented, but if the library is intended as light-weight as possible, I think most users would benefit from properly named ```var.name```.


So, to the implementation of ```var.name```. A problem is that ```MLP``` names all its ```Linear``` bricks in ```__init__``` before it passes ```kwargs[name]``` to its ancestor ```Brick``` which sets the ```self.name```. So MLP doesn't know its name when it creates ```Linear```s.

These commits would name them

```[dec_l1_b, dec_l0_b, enc_l1_b, enc_l0_b, enc_l0_W, enc_l1_W, dec_l0_W, dec_l1_W]````

Do you want such behavior and what's the most elegant way to achieve this? Two solution candidates in the latter commit.