### PR TITLE
Refactor recurrent bricks

### DIFF
--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -269,9 +269,9 @@ class SimpleRecurrent(Recurrent, Initializable):
         Parameters
         ----------
         inputs : :class:`~tensor.TensorVariable`
-            The inputs, in the shape (batch, features).
+            The 2D inputs, in the shape (batch, features).
         states : :class:`~tensor.TensorVariable`
-            The states, in the shape (batch, features).
+            The 2D states, in the shape (batch, features).
         mask : :class:`~tensor.TensorVariable`
             A 1D binary array in the shape (batch,) which is 1 if
             there is data available, 0 if not. Assumed to be 1-s

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -16,7 +16,7 @@ from blocks.utils import (pack, shared_floatx_zeros, dict_union,
                           is_shared_variable)
 
 
-class Recurrent(Brick):
+class BaseRecurrent(Brick):
     """Base class for brick with recurrent application method."""
     has_bias = False
 
@@ -215,7 +215,7 @@ def recurrent(*args, **kwargs):
         return wrap_application
 
 
-class SimpleRecurrent(Recurrent, Initializable):
+class SimpleRecurrent(BaseRecurrent, Initializable):
     """The traditional recurrent transition.
 
     The most well-known recurrent transition: a matrix multiplication,
@@ -286,7 +286,7 @@ class SimpleRecurrent(Recurrent, Initializable):
         return next_states
 
 
-class LSTM(Recurrent, Initializable):
+class LSTM(BaseRecurrent, Initializable):
     u"""Long Short Term Memory.
 
     Every unit of an LSTM is equipped with input, forget and output gates.
@@ -409,7 +409,7 @@ class LSTM(Recurrent, Initializable):
         return next_states, next_cells
 
 
-class GatedRecurrent(Recurrent, Initializable):
+class GatedRecurrent(BaseRecurrent, Initializable):
     u"""Gated recurrent neural network.
 
     Gated recurrent neural network (GRNN) as introduced in [CvMG14]_. Every
@@ -571,7 +571,7 @@ class Bidirectional(Initializable):
 
     Parameters
     ----------
-    prototype : instance of :class:`Recurrent`
+    prototype : instance of :class:`BaseRecurrent`
         A prototype brick from which the forward and backward bricks are
         cloned.
 

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -16,7 +16,7 @@ from blocks.utils import (pack, shared_floatx_zeros, dict_union,
                           is_shared_variable)
 
 
-class BaseRecurrent(Brick):
+class Recurrent(Brick):
     """Base class for brick with recurrent application method."""
     has_bias = False
 
@@ -215,18 +215,11 @@ def recurrent(*args, **kwargs):
         return wrap_application
 
 
-class Recurrent(BaseRecurrent, Initializable):
-    """Simple recurrent layer with optional activation.
+class SimpleRecurrent(Recurrent, Initializable):
+    """The traditional recurrent transition.
 
-    .. todo::
-
-       Implement deep transitions (by using other bricks). Currently, this
-       probably re-implements too much from the Linear brick.
-
-       Other important features:
-
-       * Carrying over hidden state between batches
-       * Return k last hidden states
+    The most well-known recurrent transition: a matrix multiplication,
+    optionally followed by a non-linearity.
 
     Parameters
     ----------
@@ -242,7 +235,7 @@ class Recurrent(BaseRecurrent, Initializable):
     """
     @lazy
     def __init__(self, dim, activation=None, **kwargs):
-        super(Recurrent, self).__init__(**kwargs)
+        super(SimpleRecurrent, self).__init__(**kwargs)
         if activation is None:
             activation = Identity()
         self.dim = dim
@@ -257,9 +250,10 @@ class Recurrent(BaseRecurrent, Initializable):
     def get_dim(self, name):
         if name == 'mask':
             return 0
-        if name in Recurrent.apply.sequences + Recurrent.apply.states:
+        if name in (SimpleRecurrent.apply.sequences +
+                    SimpleRecurrent.apply.states):
             return self.dim
-        return super(Recurrent, self).get_dim(name)
+        return super(SimpleRecurrent, self).get_dim(name)
 
     def _allocate(self):
         self.params.append(shared_floatx_zeros((self.dim, self.dim)))
@@ -267,41 +261,32 @@ class Recurrent(BaseRecurrent, Initializable):
     def _initialize(self):
         self.weights_init.initialize(self.W, self.rng)
 
-    @recurrent(sequences=['input_', 'mask'], states=['state'],
-               outputs=['state'], contexts=[])
-    def apply(self, input_=None, state=None, mask=None):
-        """Given data and mask, apply recurrent layer.
+    @recurrent(sequences=['inputs', 'mask'], states=['states'],
+               outputs=['states'], contexts=[])
+    def apply(self, inputs=None, states=None, mask=None):
+        """Apply the simple transition.
 
         Parameters
         ----------
-        input_ : :class:`~tensor.TensorVariable`
-            The 2 dimensional input, in the shape (batch, features).
-        state : :class:`~tensor.TensorVariable`
-            The 2 dimensional state, in the shape (batch, features).
+        inputs : :class:`~tensor.TensorVariable`
+            The inputs, in the shape (batch, features).
+        states : :class:`~tensor.TensorVariable`
+            The states, in the shape (batch, features).
         mask : :class:`~tensor.TensorVariable`
             A 1D binary array in the shape (batch,) which is 1 if
             there is data available, 0 if not. Assumed to be 1-s
             only if not given.
 
-        .. todo::
-
-           * Mask should become part of ``MaskedTensorVariable`` type so
-             that it can be passed around transparently.
-           * We should stop assuming that batches are the second dimension,
-             in order to support nested RNNs i.e. where the first n axes
-             are time, n + 1 is the batch, and n + 2, ... are features.
-             Masks will become n + 1 dimensional as well then.
-
         """
-        next_state = input_ + tensor.dot(state, self.W)
-        next_state = self.activation.apply(next_state)
+        next_states = inputs + tensor.dot(states, self.W)
+        next_states = self.activation.apply(next_states)
         if mask:
-            next_state = (mask[:, None] * next_state +
-                          (1 - mask[:, None]) * state)
-        return next_state
+            next_states = (mask[:, None] * next_states +
+                           (1 - mask[:, None]) * states)
+        return next_states
 
 
-class LSTM(BaseRecurrent, Initializable):
+class LSTM(Recurrent, Initializable):
     u"""Long Short Term Memory.
 
     Every unit of an LSTM is equipped with input, forget and output gates.
@@ -424,7 +409,7 @@ class LSTM(BaseRecurrent, Initializable):
         return next_states, next_cells
 
 
-class GatedRecurrent(BaseRecurrent, Initializable):
+class GatedRecurrent(Recurrent, Initializable):
     u"""Gated recurrent neural network.
 
     Gated recurrent neural network (GRNN) as introduced in [CvMG14]_. Every
@@ -586,7 +571,7 @@ class Bidirectional(Initializable):
 
     Parameters
     ----------
-    prototype : instance of :class:`BaseRecurrent`
+    prototype : instance of :class:`Recurrent`
         A prototype brick from which the forward and backward bricks are
         cloned.
 

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -6,7 +6,7 @@ from theano import tensor
 
 from blocks.bricks import Initializable, Identity, MLP, Random
 from blocks.bricks.base import application, Brick, lazy
-from blocks.bricks.recurrent import BaseRecurrent
+from blocks.bricks.recurrent import Recurrent
 from blocks.bricks.parallel import Fork, Distribute
 from blocks.bricks.lookup import LookupTable
 from blocks.bricks.recurrent import recurrent
@@ -285,7 +285,7 @@ class AbstractReadout(AbstractEmitter, AbstractFeedback):
 
 
 @add_metaclass(ABCMeta)
-class AbstractAttentionTransition(BaseRecurrent):
+class AbstractAttentionTransition(Recurrent):
     """A base class for a transition component of a sequence generator.
 
     A recurrent transition combined with an attention mechanism.
@@ -797,7 +797,7 @@ class SequenceGenerator(BaseSequenceGenerator):
     ----------
     readout : instance of :class:`AbstractReadout`
         The readout component for the sequence generator.
-    transition : instance of :class:`.BaseRecurrent`
+    transition : instance of :class:`.Recurrent`
         The recurrent transition to be used in the sequence generator.
         Will be combined with `attention`, if that one is given.
     attention : :class:`.Brick`

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -6,7 +6,7 @@ from theano import tensor
 
 from blocks.bricks import Initializable, Identity, MLP, Random
 from blocks.bricks.base import application, Brick, lazy
-from blocks.bricks.recurrent import Recurrent
+from blocks.bricks.recurrent import BaseRecurrent
 from blocks.bricks.parallel import Fork, Distribute
 from blocks.bricks.lookup import LookupTable
 from blocks.bricks.recurrent import recurrent
@@ -286,7 +286,7 @@ class AbstractReadout(AbstractEmitter, AbstractFeedback):
 
 
 @add_metaclass(ABCMeta)
-class AbstractAttentionTransition(Recurrent):
+class AbstractAttentionTransition(BaseRecurrent):
     """A base class for a transition component of a sequence generator.
 
     A recurrent transition combined with an attention mechanism.
@@ -798,7 +798,7 @@ class SequenceGenerator(BaseSequenceGenerator):
     ----------
     readout : instance of :class:`AbstractReadout`
         The readout component for the sequence generator.
-    transition : instance of :class:`.Recurrent`
+    transition : instance of :class:`.BaseRecurrent`
         The recurrent transition to be used in the sequence generator.
         Will be combined with `attention`, if that one is given.
     attention : :class:`.Brick`

--- a/tests/bricks/test_recurrent.py
+++ b/tests/bricks/test_recurrent.py
@@ -7,10 +7,8 @@ from numpy.testing import assert_allclose
 from theano import tensor
 
 from blocks.bricks import Tanh
-from blocks.bricks.recurrent import (GatedRecurrent,
-                                     Recurrent,
-                                     Bidirectional,
-                                     LSTM)
+from blocks.bricks.recurrent import (
+    GatedRecurrent, SimpleRecurrent, Bidirectional, LSTM)
 from blocks.initialization import Constant, IsotropicGaussian, Orthogonal
 
 
@@ -19,8 +17,8 @@ floatX = theano.config.floatX
 
 class TestRecurrent(unittest.TestCase):
     def setUp(self):
-        self.simple = Recurrent(dim=3, weights_init=Constant(2),
-                                activation=Tanh())
+        self.simple = SimpleRecurrent(dim=3, weights_init=Constant(2),
+                                      activation=Tanh())
         self.simple.initialize()
 
     def test_one_step(self):
@@ -206,11 +204,11 @@ class TestGatedRecurrent(unittest.TestCase):
 class TestBidirectional(unittest.TestCase):
     def setUp(self):
         self.bidir = Bidirectional(weights_init=Orthogonal(),
-                                   prototype=Recurrent(
+                                   prototype=SimpleRecurrent(
                                        dim=3, activation=Tanh()),
                                    seed=1)
-        self.simple = Recurrent(dim=3, weights_init=Orthogonal(),
-                                activation=Tanh(), seed=1)
+        self.simple = SimpleRecurrent(dim=3, weights_init=Orthogonal(),
+                                      activation=Tanh(), seed=1)
         self.bidir.initialize()
         self.simple.initialize()
         self.x_val = 0.1 * numpy.asarray(

--- a/tests/bricks/test_sequence_generators.py
+++ b/tests/bricks/test_sequence_generators.py
@@ -6,7 +6,7 @@ from theano import tensor
 from blocks.bricks import Tanh
 from blocks.bricks.base import application
 from blocks.bricks.parallel import Distribute
-from blocks.bricks.recurrent import Recurrent, GatedRecurrent
+from blocks.bricks.recurrent import SimpleRecurrent, GatedRecurrent
 from blocks.bricks.attention import SequenceContentAttention
 from blocks.bricks.sequence_generators import (
     SequenceGenerator, LinearReadout, TrivialEmitter,
@@ -104,7 +104,7 @@ def test_integer_sequence_generator():
     assert costs_val.shape == (n_steps, batch_size)
 
 
-class TestTransition(Recurrent):
+class TestTransition(SimpleRecurrent):
     def __init__(self, attended_dim, **kwargs):
         super(TestTransition, self).__init__(**kwargs)
         self.attended_dim = attended_dim
@@ -153,7 +153,7 @@ def test_attention_transition():
     inputs = tensor.tensor3("inputs")
     inputs_mask = tensor.matrix("inputs_mask")
     states, glimpses, weights = att_trans.apply(
-        input_=inputs, mask=inputs_mask,
+        inputs=inputs, mask=inputs_mask,
         attended=attended, attended_mask=attended_mask)
     assert states.ndim == 3
     assert glimpses.ndim == 3
@@ -180,7 +180,7 @@ def test_attention_transition():
 
     # Test SequenceGenerator using AttentionTransition
     generator = SequenceGenerator(
-        LinearReadout(readout_dim=inp_dim, source_names=["state"],
+        LinearReadout(readout_dim=inp_dim, source_names=["states"],
                       emitter=TestEmitter(name="emitter"),
                       name="readout"),
         transition=transition,


### PR DESCRIPTION
There are a few issues I would like to solve with this commit. First, I do not like that a very generic name `Recurrent` belongs to a particular, the simplest one in fact, recurrent transition. Second, it is nice to have uniform argument names, such as "inputs" and "states" for all recurrent transition. Finally, there were some out-dated todo's in the code.