### PR TITLE
And on_error callback

### DIFF
--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -59,6 +59,11 @@ class TrainingExtension(object):
 
     def on_resumption(self):
         """The callback invoked after training is resumed."""
+        pass
+
+    def on_error(self):
+        """The callback invoked when an error occurs."""
+        pass
 
     def before_training(self):
         """The callback invoked before training is started."""


### PR DESCRIPTION
Solves #154.

Such things are not really convenient to test, so I will carefully describe here in plain English what the new error handling strategy is. When a error occurs, we make a record in the log and notify user that the extensions are called. Then the `on_error` callbacks (new!) are invoked. If any of those fail, we just go ahead, calling `logger.error` though. Finally, we reraise the exception.  A care is taken not to invoke "after_training" callbacks when finishing because of an error.

The advantages of the new scheme:

* one can use the debugger to figure out what the problem was

* it is possible to do something with the errored main loop, for instance to save it under another name

The saving for the last item is not implemented yet, but can be easily coded when this PR is merged.