### PR TITLE
Step rule refactor (fixes #266)

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -309,14 +309,14 @@ class CompositeRule(StepRule):
 class Scale(StepRule):
     """A step in the direction proportional to the previous step.
 
-    If the previous step is the gradient itself, this step rule is equivalent
-    to steepest ascent.
+    If the previous step is the gradient itself, this step rule is
+    equivalent to steepest ascent.
 
     Parameters
     ----------
     learning_rate : float
-        The learning rate by which the previous step is multiplied to produce
-        the step.
+        The learning rate by which the previous step is multiplied to
+        produce the step.
 
     Attributes
     ----------

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -331,13 +331,19 @@ class Scale(StepRule):
         return self.learning_rate * previous_step, []
 
 
-class Momentum(StepRule):
+class BasicMomentum(StepRule):
     """Accumulates step with exponential discount.
 
     Parameters
     ----------
     momentum : float, optional
-        The momentum coefficient.
+        The momentum coefficient. Defaults to 0.
+
+    Notes
+    -----
+    This step rule is intended to be used in conjunction with another
+    step rule, _e.g._ :class:`Scale`. For an all-batteries-included
+    experience, look at :class:`Momentum`.
 
     """
     def __init__(self, momentum=0.):
@@ -348,6 +354,25 @@ class Momentum(StepRule):
         step = self.momentum * velocity + previous_step
         updates = [(velocity, step)]
         return step, updates
+
+
+class Momentum(CompositeRule):
+    """Accumulates step with exponential discount.
+
+    Combines :class:`BasicMomentum` and :class:`Scale` to form the
+    usual momentum step rule.
+
+    Parameters
+    ----------
+    learning_rate : float, optional
+        The learning rate by which the previous step scaled. Defaults to 1.
+    momentum : float, optional
+        The momentum coefficient. Defaults to 0.
+
+    """
+    def __init__(self, learning_rate=1.0, momentum=0.):
+        self.components = [Scale(learning_rate=learning_rate),
+                           BasicMomentum(momentum=momentum)]
 
 
 class AdaDelta(StepRule):

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -165,7 +165,7 @@ class GradientDescent(DifferentiableCostMinimizer):
         steps.  Note, that the step rule might have a state, e.g. to
         remember a weighted sum of gradients from previous steps like it is
         done in gradient descent with momentum. If ``None``, an instance of
-        :class:`SteepestDescent` is created.
+        :class:`Scale` is created.
     gradients : dict, optional
         A dictionary mapping a parameter to an expression for the cost's
         gradient with respect to the parameter. If ``None``, the gradient
@@ -190,7 +190,7 @@ class GradientDescent(DifferentiableCostMinimizer):
             self.gradients = dict(
                 zip(self.params, tensor.grad(self.cost, self.params)))
             logger.info("The cost gradient computation graph is built")
-        self.step_rule = step_rule if step_rule else SteepestDescent()
+        self.step_rule = step_rule if step_rule else Scale()
 
         self.total_gradient_norm = named_copy(l2_norm(self.gradients.values()),
                                               "total_gradient_norm")
@@ -224,7 +224,7 @@ class GradientDescent(DifferentiableCostMinimizer):
 @add_metaclass(ABCMeta)
 class StepRule(object):
     """A rule to compute steps for a gradient descent algorithm."""
-    def compute_step(self, param, gradient):
+    def compute_step(self, param, previous_step):
         """Build a Theano expression for the step for a parameter.
 
         This method is called by default implementation of
@@ -234,8 +234,10 @@ class StepRule(object):
         ----------
         param : :class:`~tensor.TensorSharedVariable`
             The parameter.
-        gradient : :class:`~tensor.TensorVariable`
-            The gradient of the cost with respect to the parameter.
+        previous_step : :class:`~tensor.TensorVariable`
+            Some quantity related to the gradient of the cost with respect
+            to the parameter, either the gradient itself or a step in a
+            related direction.
 
         Returns
         -------
@@ -247,35 +249,37 @@ class StepRule(object):
         """
         raise NotImplementedError
 
-    def compute_steps(self, gradients):
+    def compute_steps(self, previous_steps):
         """Build a Theano expression for steps for all parameters.
 
-        Override this method if you want to process the gradient
+        Override this method if you want to process the steps
         with respect to all parameters as a whole, not parameter-wise.
 
         Parameters
         ----------
-        gradients : OrderedDict
+        previous_steps : OrderedDict
             An :class:`~OrderedDict` of
             (:class:`~tensor.TensorSharedVariable`
             :class:`~tensor.TensorVariable`) pairs. The keys are the
             parameters being trained, the values are the expressions for
-            the gradients of the cost with respect to the parameters.
+            quantities related to gradients of the cost with respect to
+            the parameters, either the gradients themselves or steps in
+            related directions.
 
         Returns
         -------
         steps : OrderedDict
             A dictionary of the proposed steps in the same form as
-            `gradients`.
+            `previous_steps`.
         updates : list
             A list of tuples representing updates to be performed.
 
         """
-        parameter_wise = [self.compute_step(param, gradients[param])
-                          for param in gradients]
+        parameter_wise = [self.compute_step(param, previous_steps[param])
+                          for param in previous_steps]
         (steps, updates) = zip(*parameter_wise)
         steps = OrderedDict((param, step) for param, step
-                            in zip(gradients.keys(), steps))
+                            in zip(previous_steps.keys(), steps))
         updates = list(itertools.chain(*updates))
         return steps, updates
 
@@ -293,23 +297,26 @@ class CompositeRule(StepRule):
     def __init__(self, components):
         self.components = components
 
-    def compute_steps(self, gradients):
-        result = gradients
+    def compute_steps(self, previous_steps):
+        steps = previous_steps
         updates = []
         for rule in self.components:
-            result, more_updates = rule.compute_steps(result)
+            steps, more_updates = rule.compute_steps(steps)
             updates += more_updates
-        return result, updates
+        return steps, updates
 
 
-class SteepestDescent(StepRule):
-    """A step in the direction proportional to the gradient.
+class Scale(StepRule):
+    """A step in the direction proportional to the previous step.
+
+    If the previous step is the gradient itself, this step rule is equivalent
+    to steepest ascent.
 
     Parameters
     ----------
     learning_rate : float
-        The learning rate by which the gradient is multiplied to produce
-        the descent step.
+        The learning rate by which the previous step is multiplied to produce
+        the step.
 
     Attributes
     ----------
@@ -320,12 +327,12 @@ class SteepestDescent(StepRule):
     def __init__(self, learning_rate=1.0):
         self.learning_rate = shared_floatx(learning_rate)
 
-    def compute_step(self, param, gradient):
-        return self.learning_rate * gradient, []
+    def compute_step(self, param, previous_step):
+        return self.learning_rate * previous_step, []
 
 
 class Momentum(StepRule):
-    """Accumulates gradients with exponential discount.
+    """Accumulates step with exponential discount.
 
     Parameters
     ----------
@@ -336,9 +343,9 @@ class Momentum(StepRule):
     def __init__(self, momentum=0.):
         self.momentum = shared_floatx(momentum)
 
-    def compute_step(self, param, gradient):
+    def compute_step(self, param, previous_step):
         velocity = shared_floatx(param.get_value() * 0.)
-        step = self.momentum * velocity + gradient
+        step = self.momentum * velocity + previous_step
         updates = [(velocity, step)]
         return step, updates
 
@@ -367,18 +374,18 @@ class AdaDelta(StepRule):
         self.decay_rate = shared_floatx(decay_rate)
         self.epsilon = shared_floatx(epsilon)
 
-    def compute_step(self, param, gradient):
-        mean_square_grad_tm1 = shared_floatx(param.get_value() * 0.)
+    def compute_step(self, param, previous_step):
+        mean_square_step_tm1 = shared_floatx(param.get_value() * 0.)
         mean_square_delta_x_tm1 = shared_floatx(param.get_value() * 0.)
 
-        mean_square_grad_t = (
-            self.decay_rate * mean_square_grad_tm1 +
-            (1 - self.decay_rate) * tensor.sqr(gradient)
+        mean_square_step_t = (
+            self.decay_rate * mean_square_step_tm1 +
+            (1 - self.decay_rate) * tensor.sqr(previous_step)
         )
 
         rms_delta_x_tm1 = tensor.sqrt(mean_square_delta_x_tm1 + self.epsilon)
-        rms_grad_t = tensor.sqrt(mean_square_grad_t + self.epsilon)
-        delta_x_t = rms_delta_x_tm1 / rms_grad_t * gradient
+        rms_step_t = tensor.sqrt(mean_square_step_t + self.epsilon)
+        delta_x_t = rms_delta_x_tm1 / rms_step_t * previous_step
 
         mean_square_delta_x_t = (
             self.decay_rate * mean_square_delta_x_tm1 +
@@ -386,13 +393,13 @@ class AdaDelta(StepRule):
         )
 
         step = delta_x_t
-        updates = [(mean_square_grad_tm1, mean_square_grad_t),
+        updates = [(mean_square_step_tm1, mean_square_step_t),
                    (mean_square_delta_x_tm1, mean_square_delta_x_t)]
         return step, updates
 
 
 class BasicRMSProp(StepRule):
-    """Scales the step size by a running average of the recent gradient norms.
+    """Scales the step size by a running average of the recent step norms.
 
     Parameters
     ----------
@@ -406,13 +413,13 @@ class BasicRMSProp(StepRule):
     Notes
     -----
     This step rule is intended to be used in conjunction with another
-    step rule, _e.g._ :class:`SteepestDescent`. For an
-    all-batteries-included experience, look at :class:`RMSProp`.
+    step rule, _e.g._ :class:`Scale`. For an all-batteries-included
+    experience, look at :class:`RMSProp`.
 
     In general, this step rule should be used _before_ other step rules,
     because it has normalization properties that may undo their work.
     For instance, it should be applied first when used in conjunction
-    with :class:`SteepestDescent`.
+    with :class:`Scale`.
 
     For more information, see [RMSProp]_.
 
@@ -429,25 +436,28 @@ class BasicRMSProp(StepRule):
         self.decay_rate = shared_floatx(decay_rate)
         self.epsilon = 1. / max_scaling
 
-    def compute_step(self, param, gradient):
-        mean_square_grad_tm1 = shared_floatx(param.get_value() * 0.)
-        mean_square_grad_t = (self.decay_rate * mean_square_grad_tm1 +
-                              (1 - self.decay_rate) * tensor.sqr(gradient))
-        rms_grad_t = tensor.maximum(
-            tensor.sqrt(mean_square_grad_t), self.epsilon)
-        step = gradient / rms_grad_t
-        updates = [(mean_square_grad_tm1, mean_square_grad_t)]
+    def compute_step(self, param, previous_step):
+        mean_square_step_tm1 = shared_floatx(param.get_value() * 0.)
+        mean_square_step_t = (
+            self.decay_rate * mean_square_step_tm1 +
+            (1 - self.decay_rate) * tensor.sqr(previous_step))
+        rms_step_t = tensor.maximum(
+            tensor.sqrt(mean_square_step_t), self.epsilon)
+        step = previous_step / rms_step_t
+        updates = [(mean_square_step_tm1, mean_square_step_t)]
         return step, updates
 
 
 class RMSProp(CompositeRule):
-    """Scales the step size by a running average of the recent gradient norms.
+    """Scales the step size by a running average of the recent step norms.
+
+    Combines :class:`BasicRMSProp` and :class:`Scale` to form the step rule
+    described in [RMSProp]_.
 
     Parameters
     ----------
     learning_rate : float, optional
-        The learning rate by which the gradient is multiplied to produce
-        the descent step. Defaults to 1.
+        The learning rate by which the previous step scaled. Defaults to 1.
     decay_rate : float, optional
         How fast the running average decays (lower is faster).
         Defaults to 0.9.
@@ -467,16 +477,19 @@ class RMSProp(CompositeRule):
     def __init__(self, learning_rate=1.0, decay_rate=0.9, max_scaling=1e5):
         self.components = [
             BasicRMSProp(decay_rate=decay_rate, max_scaling=max_scaling),
-            SteepestDescent(learning_rate=learning_rate)]
+            Scale(learning_rate=learning_rate)]
 
 
-class GradientClipping(StepRule):
-    """Clips the total gradient to make it not exceed a threshold.
+class StepClipping(StepRule):
+    """Clips the total step to make it not exceed a threshold.
+
+    When the previous steps are the gradients, this step rule performs
+    gradient clipping.
 
     Parameters
     ----------
     threshold : float, optional
-        The maximum permitted L2 norm for the gradient. The gradient
+        The maximum permitted L2 norm for the step. The step
         will be rescaled to be not higher than this quanity.
         If ``None``, no rescaling will be applied.
 
@@ -490,13 +503,13 @@ class GradientClipping(StepRule):
         if threshold:
             self.threshold = shared_floatx(threshold)
 
-    def compute_steps(self, gradients):
+    def compute_steps(self, previous_steps):
         if not hasattr(self, 'threshold'):
-            return gradients
-        norm = l2_norm(gradients.values())
+            return previous_steps
+        norm = l2_norm(previous_steps.values())
         multiplier = tensor.switch(norm < self.threshold,
                                    1, self.threshold / norm)
         steps = OrderedDict(
-            (param, gradient * multiplier)
-            for param, gradient in gradients.items())
+            (param, step * multiplier)
+            for param, step in previous_steps.items())
         return steps, []

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,7 @@ Quickstart
    :hide:
 
    >>> from theano import tensor
-   >>> from blocks.algorithms import GradientDescent, SteepestDescent
+   >>> from blocks.algorithms import GradientDescent, Scale
    >>> from blocks.bricks import MLP, Tanh, Softmax
    >>> from blocks.bricks.cost import CategoricalCrossEntropy, MisclassificationRate
    >>> from blocks.initialization import IsotropicGaussian, Constant
@@ -91,7 +91,7 @@ And train!
 >>> main_loop = MainLoop(
 ...     model=mlp, data_stream=train_stream,
 ...     algorithm=GradientDescent(
-...         cost=cost, step_rule=SteepestDescent(learning_rate=0.1)),
+...         cost=cost, step_rule=Scale(learning_rate=0.1)),
 ...     extensions=[FinishAfter(after_n_epochs=5),
 ...                 DataStreamMonitoring(
 ...                     variables=[cost, error_rate],

--- a/docs/plotting.rst
+++ b/docs/plotting.rst
@@ -49,7 +49,7 @@ We train on a 150 random points in :math:`[0, 1]`.
 Now let's train with gradient descent and plot the results.
 
 >>> from blocks.main_loop import MainLoop
->>> from blocks.algorithms import GradientDescent, SteepestDescent
+>>> from blocks.algorithms import GradientDescent, Scale
 >>> from blocks.extensions import FinishAfter
 >>> from blocks.extensions.monitoring import TrainingDataMonitoring
 >>> from blocks.extensions.plot import Plot
@@ -58,7 +58,7 @@ Now let's train with gradient descent and plot the results.
 >>> main_loop = MainLoop(
 ...     model=None, data_stream=data_stream,
 ...     algorithm=GradientDescent(cost=cost,
-...                               step_rule=SteepestDescent(learning_rate=0.1)),
+...                               step_rule=Scale(learning_rate=0.1)),
 ...     extensions=[FinishAfter(after_n_epochs=1),
 ...                 TrainingDataMonitoring([cost, a_copy], after_every_batch=True),
 ...                 Plot('Plotting example', channels=[['cost'], ['a']],

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -172,8 +172,8 @@ of size 256.
 
 As our algorithm we will use straightforward SGD with a fixed learning rate.
 
->>> from blocks.algorithms import GradientDescent, SteepestDescent
->>> algorithm = GradientDescent(cost=cost, step_rule=SteepestDescent(learning_rate=0.1))
+>>> from blocks.algorithms import GradientDescent, Scale
+>>> algorithm = GradientDescent(cost=cost, step_rule=Scale(learning_rate=0.1))
 
 During training we will want to monitor the performance of our model on
 a separate set of examples. Let's create a new data stream for that.

--- a/examples/markov_chain/main.py
+++ b/examples/markov_chain/main.py
@@ -19,7 +19,7 @@ from blocks.bricks.sequence_generators import (
 from blocks.graph import ComputationGraph
 from blocks.datasets.streams import DataStream
 from blocks.datasets.schemes import ConstantScheme
-from blocks.algorithms import GradientDescent, SteepestDescent
+from blocks.algorithms import GradientDescent, Scale
 from blocks.initialization import Orthogonal, IsotropicGaussian, Constant
 from blocks.monitoring import aggregation
 from blocks.extensions import FinishAfter, Printing
@@ -80,7 +80,7 @@ def main(mode, save_path, steps, num_batches):
 
         algorithm = GradientDescent(
             cost=cost, params=list(Selector(generator).get_params().values()),
-            step_rule=SteepestDescent(0.001))
+            step_rule=Scale(0.001))
         main_loop = MainLoop(
             model=generator,
             data_stream=DataStream(

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser
 
 from theano import tensor
 
-from blocks.algorithms import GradientDescent, SteepestDescent
+from blocks.algorithms import GradientDescent, Scale
 from blocks.bricks import MLP, Tanh, Softmax, WEIGHTS
 from blocks.bricks.cost import CategoricalCrossEntropy, MisclassificationRate
 from blocks.initialization import IsotropicGaussian, Constant
@@ -43,7 +43,7 @@ def main(save_to, num_epochs):
     mnist_test = MNIST("test")
 
     algorithm = GradientDescent(
-        cost=cost, step_rule=SteepestDescent(learning_rate=0.1))
+        cost=cost, step_rule=Scale(learning_rate=0.1))
     main_loop = MainLoop(
         mlp,
         DataStream(mnist_train,

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -24,8 +24,8 @@ from blocks.datasets.streams import (
     DataStreamFilter)
 from blocks.datasets.text import OneBillionWord
 from blocks.datasets.schemes import ConstantScheme
-from blocks.algorithms import (GradientDescent, SteepestDescent,
-                               GradientClipping, CompositeRule)
+from blocks.algorithms import (GradientDescent, Scale,
+                               StepClipping, CompositeRule)
 from blocks.initialization import Orthogonal, IsotropicGaussian, Constant
 from blocks.monitoring import aggregation
 from blocks.extensions import FinishAfter, Printing, Timing
@@ -192,8 +192,8 @@ def main(mode, save_path, num_batches, from_dump):
 
         # Define the training algorithm.
         algorithm = GradientDescent(
-            cost=cost, step_rule=CompositeRule([GradientClipping(10.0),
-                                                SteepestDescent(0.01)]))
+            cost=cost, step_rule=CompositeRule([StepClipping(10.0),
+                                                Scale(0.01)]))
 
         observables = [
             cost, min_energy, max_energy, mean_activation,

--- a/examples/sqrt.py
+++ b/examples/sqrt.py
@@ -13,7 +13,7 @@ from argparse import ArgumentParser
 import theano
 from theano import tensor
 
-from blocks.algorithms import GradientDescent, SteepestDescent
+from blocks.algorithms import GradientDescent, Scale
 from blocks.bricks import MLP, Tanh, Identity
 from blocks.bricks.cost import SquaredError
 from blocks.initialization import IsotropicGaussian, Constant
@@ -54,7 +54,7 @@ def main(save_to, num_batches, continue_=False):
         mlp,
         get_data_stream(range(100)),
         GradientDescent(
-            cost=cost, step_rule=SteepestDescent(learning_rate=0.001)),
+            cost=cost, step_rule=Scale(learning_rate=0.001)),
         extensions=([LoadFromDump(save_to)] if continue_ else []) +
         [Timing(),
             FinishAfter(after_n_batches=num_batches),

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -6,8 +6,8 @@ from numpy.testing import assert_allclose, assert_raises
 from theano import tensor
 
 from blocks.algorithms import (GradientDescent, StepClipping, CompositeRule,
-                               Scale, StepRule, Momentum, AdaDelta,
-                               BasicRMSProp, RMSProp)
+                               Scale, StepRule, BasicMomentum, Momentum,
+                               AdaDelta, BasicRMSProp, RMSProp)
 from blocks.utils import shared_floatx
 
 
@@ -37,15 +37,26 @@ def test_gradient_descent_with_gradients():
     assert_allclose(W.get_value(), -0.5 * W_start_value)
 
 
-def test_momentum():
+def test_basic_momentum():
     a = shared_floatx([3, 4])
     cost = (a ** 2).sum()
-    steps, updates = Momentum(0.5).compute_steps(
+    steps, updates = BasicMomentum(0.5).compute_steps(
         OrderedDict([(a, tensor.grad(cost, a))]))
     f = theano.function([], [steps[a]], updates=updates)
     assert_allclose(f()[0], [6., 8.])
     assert_allclose(f()[0], [9., 12.])
     assert_allclose(f()[0], [10.5, 14.])
+
+
+def test_momentum():
+    a = shared_floatx([3, 4])
+    cost = (a ** 2).sum()
+    steps, updates = Momentum(0.1, 0.5).compute_steps(
+        OrderedDict([(a, tensor.grad(cost, a))]))
+    f = theano.function([], [steps[a]], updates=updates)
+    assert_allclose(f()[0], [0.6, 0.8])
+    assert_allclose(f()[0], [0.9, 1.2])
+    assert_allclose(f()[0], [1.05, 1.4])
 
 
 def test_adadelta():

--- a/tests/extensions/test_monitoring.py
+++ b/tests/extensions/test_monitoring.py
@@ -7,7 +7,7 @@ from blocks.datasets import ContainerDataset
 from blocks.extensions import TrainingExtension, FinishAfter
 from blocks.extensions.monitoring import TrainingDataMonitoring
 from blocks.monitoring import aggregation
-from blocks.algorithms import GradientDescent, SteepestDescent
+from blocks.algorithms import GradientDescent, Scale
 from blocks.utils import shared_floatx, named_copy
 from blocks.main_loop import MainLoop
 
@@ -40,7 +40,7 @@ def test_training_data_monitoring():
     main_loop = MainLoop(
         model=None, data_stream=dataset.get_default_stream(),
         algorithm=GradientDescent(cost=cost, params=[W],
-                                  step_rule=SteepestDescent(0.001)),
+                                  step_rule=Scale(0.001)),
         extensions=[
             FinishAfter(after_n_epochs=1),
             TrainingDataMonitoring([W_sum, cost, V], "train1",

--- a/tests/extensions/test_training.py
+++ b/tests/extensions/test_training.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 import theano
 from theano import tensor
 
-from blocks.algorithms import GradientDescent, SteepestDescent
+from blocks.algorithms import GradientDescent, Scale
 from blocks.datasets import ContainerDataset
 from blocks.extensions import FinishAfter
 from blocks.extensions.training import SharedVariableModifier
@@ -28,7 +28,7 @@ def test_shared_variable_modifier():
     cost = ((x * W).sum() - y) ** 2
     cost.name = 'cost'
 
-    step_rule = SteepestDescent(0.001)
+    step_rule = Scale(0.001)
     sgd = GradientDescent(cost=cost, params=[W],
                           step_rule=step_rule)
     main_loop = MainLoop(
@@ -60,7 +60,7 @@ def test_shared_variable_modifier_two_params():
     cost = ((x * W).sum() - y) ** 2
     cost.name = 'cost'
 
-    step_rule = SteepestDescent(0.001)
+    step_rule = Scale(0.001)
     sgd = GradientDescent(cost=cost, params=[W],
                           step_rule=step_rule)
     modifier = SharedVariableModifier(


### PR DESCRIPTION
The following is performed in this pull request:

* The term `step` is used instead of `gradient` in `StepRule` and its subclasses.
* The `SteepestDescent` step rule is renamed to `Scale`.
* The `GradientClipping` step rule is renamed to `StepClipping`.
* The `Momentum` step rule is split into `BasicMomentum` and `Momentum`.