### PR TITLE
Speed up reverse words demo and add it to tests

### DIFF
--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -13,7 +13,7 @@ from theano import tensor
 
 from blocks.bricks import Tanh, application
 from blocks.bricks.lookup import LookupTable
-from blocks.bricks.recurrent import GatedRecurrent, Bidirectional
+from blocks.bricks.recurrent import SimpleRecurrent, Bidirectional
 from blocks.bricks.attention import SequenceContentAttention
 from blocks.bricks.parallel import Fork
 from blocks.bricks.sequence_generators import (
@@ -66,7 +66,7 @@ def reverse_words(sample):
     return (result,)
 
 
-class Transition(GatedRecurrent):
+class Transition(SimpleRecurrent):
     def __init__(self, attended_dim, **kwargs):
         super(Transition, self).__init__(**kwargs)
         self.attended_dim = attended_dim
@@ -118,7 +118,7 @@ def main(mode, save_path, num_batches, from_dump):
         targets_mask = tensor.matrix("targets_mask")
 
         encoder = Bidirectional(
-            GatedRecurrent(dim=dimension, activation=Tanh()),
+            SimpleRecurrent(dim=dimension, activation=Tanh()),
             weights_init=Orthogonal())
         encoder.initialize()
         fork = Fork([name for name in encoder.prototype.apply.sequences

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,10 @@
+import logging
 import sys
 from functools import wraps
 
 from six import StringIO
+
+import blocks
 
 
 def silence_printing(test):
@@ -9,8 +12,12 @@ def silence_printing(test):
     def wrapper(*args, **kwargs):
         stdout = sys.stdout
         sys.stdout = StringIO()
+        logger = logging.getLogger(blocks.__name__)
+        old_level = logger.level
+        logger.setLevel(logging.ERROR)
         try:
             test(*args, **kwargs)
         finally:
             sys.stdout = stdout
+            logger.setLevel(old_level)
     return wrapper

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import tempfile
 
 import dill
@@ -38,6 +39,9 @@ def test_markov_chain():
 @silence_printing
 def test_reverse_words():
     theano.config.optimizer = 'fast_compile'
-    with tempfile.NamedTemporaryFile() as f:
-        reverse_words_test("train", f.name, 1, False)
-
+    with tempfile.NamedTemporaryFile() as f_save,\
+         tempfile.NamedTemporaryFile() as f_data:
+        with open(f_data.name, 'wt') as data:
+            for i in range(10):
+                print("A line.", file=data)
+        reverse_words_test("train", f_save.name, 1, False, [f_data.name])

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -29,7 +29,7 @@ def test_mnist():
         with open(f.name, "rb") as source:
             main_loop = dill.load(source)
         main_loop.find_extension("FinishAfter").set_conditions(
-            after_n_epochs=1)
+            after_n_epochs=2)
         main_loop.run()
         assert main_loop.log.status.epochs_done == 2
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -23,6 +23,7 @@ def test_sqrt():
     assert main_loop.log[7][SAVED_TO] == save_path
 
 
+@silence_printing
 def test_mnist():
     with tempfile.NamedTemporaryFile() as f:
         mnist_test(f.name, 1)


### PR DESCRIPTION
I want to include the reverse words demo in our automatic tests because the sequence generation framework is about to be refactored and beam search is in development #279. By switching to `SimpleRecurrent` and disabling agressive optimization I managed to get it as fast as 16 seconds on Python 3: that's a lot but I think that short-term benefits of having such a test overweight this slow down.

Also includes some refactoring.