### PR TITLE
Fix W503 pep8 error

### DIFF
--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -299,8 +299,8 @@ class Maxout(Brick):
         """
         last_dim = input_.shape[-1]
         output_dim = last_dim // self.num_pieces
-        new_shape = ([input_.shape[i] for i in range(input_.ndim - 1)]
-                     + [output_dim, self.num_pieces])
+        new_shape = ([input_.shape[i] for i in range(input_.ndim - 1)] +
+                     [output_dim, self.num_pieces])
         output = tensor.max(input_.reshape(new_shape, ndim=input_.ndim + 1),
                             axis=input_.ndim)
         return output

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -145,8 +145,8 @@ class SequenceContentAttention(Initializable):
 
     @take_look.property('inputs')
     def take_look_inputs(self):
-        return (['sequence', 'preprocessed_sequence', 'mask']
-                + self.state_names)
+        return (['sequence', 'preprocessed_sequence', 'mask'] +
+                self.state_names)
 
     @application
     def initial_glimpses(self, name, batch_size, sequence):

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -780,8 +780,8 @@ def lazy(func):
 
         # Check if positional arguments were passed as keyword arguments
         args = list(args)
-        for i, arg_name in enumerate(arg_names[:len(arg_names)
-                                               - len(defaults)]):
+        for i, arg_name in enumerate(arg_names[:len(arg_names) -
+                                               len(defaults)]):
             if arg_name in kwargs:
                 if args[i] is not None:
                     raise ValueError

--- a/blocks/bricks/cost.py
+++ b/blocks/bricks/cost.py
@@ -65,5 +65,5 @@ class CategoricalCrossEntropy(Cost):
 class MisclassificationRate(Cost):
     @application(outputs=["error_rate"])
     def apply(self, y, y_hat):
-        return (tensor.sum(tensor.neq(y, y_hat.argmax(axis=1)))
-                / y.shape[0].astype(floatX))
+        return (tensor.sum(tensor.neq(y, y_hat.argmax(axis=1))) /
+                y.shape[0].astype(floatX))

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -180,9 +180,9 @@ def recurrent(*args, **kwargs):
                 kwargs = dict(zip(arg_names, args))
                 kwargs.update(rest_kwargs)
                 return application_function(brick, **kwargs)
-            outputs_info = (list(states_given.values())
-                            + [None] * (len(application.outputs) -
-                                        len(application.states)))
+            outputs_info = (list(states_given.values()) +
+                            [None] * (len(application.outputs) -
+                                      len(application.states)))
             result, updates = theano.scan(
                 scan_function, sequences=list(sequences_given.values()),
                 outputs_info=outputs_info,
@@ -544,12 +544,12 @@ class GatedRecurrent(BaseRecurrent, Initializable):
         if self.use_update_gate:
             update_values = self.gate_activation.apply(
                 states.dot(self.state_to_update) + update_inputs)
-            next_states = (next_states * update_values
-                           + states * (1 - update_values))
+            next_states = (next_states * update_values +
+                           states * (1 - update_values))
 
         if mask:
-            next_states = (mask[:, None] * next_states
-                           + (1 - mask[:, None]) * states)
+            next_states = (mask[:, None] * next_states +
+                           (1 - mask[:, None]) * states)
 
         return next_states
 

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -212,8 +212,8 @@ class BaseSequenceGenerator(Initializable):
         next_states = self.transition.compute_states(
             return_list=True,
             **dict_union(next_inputs, states, next_glimpses, contexts))
-        return (next_states + [next_outputs]
-                + list(next_glimpses.values()) + [next_costs])
+        return (next_states + [next_outputs] +
+                list(next_glimpses.values()) + [next_costs])
 
     @generate.delegate
     def generate_delegate(self):
@@ -225,8 +225,8 @@ class BaseSequenceGenerator(Initializable):
 
     @generate.property('outputs')
     def generate_outputs(self):
-        return (self.state_names + ['outputs']
-                + self.glimpse_names + ['costs'])
+        return (self.state_names + ['outputs'] +
+                self.glimpse_names + ['costs'])
 
     def get_dim(self, name):
         if name in self.state_names + self.context_names + self.glimpse_names:
@@ -456,8 +456,8 @@ class SoftmaxEmitter(AbstractEmitter, Initializable, Random):
         flat_outputs = outputs.flatten()
         num_outputs = flat_outputs.shape[0]
         return -tensor.log(
-            probs.flatten()[max_output * tensor.arange(num_outputs)
-                            + flat_outputs].reshape(outputs.shape))
+            probs.flatten()[max_output * tensor.arange(num_outputs) +
+                            flat_outputs].reshape(outputs.shape))
 
     @application
     def initial_outputs(self, batch_size, *args, **kwargs):

--- a/blocks/datasets/streams.py
+++ b/blocks/datasets/streams.py
@@ -238,9 +238,9 @@ class ForceFloatX(DataStreamWrapper):
         data = next(self.child_epoch_iterator)
         result = []
         for piece in data:
-            if (isinstance(piece, numpy.ndarray)
-                    and piece.dtype.kind == "f"
-                    and piece.dtype != floatX):
+            if (isinstance(piece, numpy.ndarray) and
+                    piece.dtype.kind == "f" and
+                    piece.dtype != floatX):
                 result.append(piece.astype(floatX))
             else:
                 result.append(piece)

--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -273,8 +273,8 @@ class SimpleExtension(TrainingExtension):
 
         """
         for callback_name, predicate, arguments in self._conditions:
-            if (callback_name == callback_invoked
-                    and predicate(self.main_loop.log)):
+            if (callback_name == callback_invoked and
+                    predicate(self.main_loop.log)):
                 self.do(callback_invoked, *(from_main_loop + tuple(arguments)))
 
 

--- a/blocks/filter.py
+++ b/blocks/filter.py
@@ -131,11 +131,11 @@ class VariableFilter(object):
             variables = filtered_variables
         if self.name:
             variables = [var for var in variables
-                         if hasattr(var.tag, 'name')
-                         and re.match(self.name, var.tag.name)]
+                         if hasattr(var.tag, 'name') and
+                         re.match(self.name, var.tag.name)]
         if self.application:
             variables = [var for var in variables
-                         if get_application_call(var)
-                         and get_application_call(var).application
-                         == self.application]
+                         if get_application_call(var) and
+                         get_application_call(var).application ==
+                         self.application]
         return variables

--- a/blocks/graph.py
+++ b/blocks/graph.py
@@ -160,8 +160,8 @@ class ComputationGraph(object):
 
         """
         role_variables = [var for var in self.variables
-                          if hasattr(var.tag, "roles")
-                          and not is_shared_variable(var)]
+                          if hasattr(var.tag, "roles") and
+                          not is_shared_variable(var)]
         value_holders = [shared_like(var) for var in role_variables]
         function = self.get_theano_function(zip(value_holders, role_variables))
         function(*(data[input_.name] for input_ in self.inputs))

--- a/tests/bricks/test_recurrent.py
+++ b/tests/bricks/test_recurrent.py
@@ -168,8 +168,8 @@ class TestGatedRecurrent(unittest.TestCase):
 
         z_val = numpy.tanh(h0_val.dot(W_val) + zi_val)
         r_val = numpy.tanh(h0_val.dot(W_val) + ri_val)
-        h1_val = (z_val * numpy.tanh((r_val * h0_val).dot(W_val) + x_val)
-                  + (1 - z_val) * h0_val)
+        h1_val = (z_val * numpy.tanh((r_val * h0_val).dot(W_val) + x_val) +
+                  (1 - z_val) * h0_val)
         assert_allclose(h1_val, next_h(h0_val, x_val, zi_val, ri_val)[0],
                         rtol=1e-6)
 
@@ -192,8 +192,8 @@ class TestGatedRecurrent(unittest.TestCase):
 
         for i in range(1, 25):
             r_val = numpy.tanh(h_val[i - 1].dot(U) + ri_val[i - 1])
-            h_val[i] = numpy.tanh((r_val * h_val[i - 1]).dot(W)
-                                  + x_val[i - 1])
+            h_val[i] = numpy.tanh((r_val * h_val[i - 1]).dot(W) +
+                                  x_val[i - 1])
             h_val[i] = (mask_val[i - 1, :, None] * h_val[i] +
                         (1 - mask_val[i - 1, :, None]) * h_val[i - 1])
         h_val = h_val[1:]
@@ -214,8 +214,8 @@ class TestBidirectional(unittest.TestCase):
         self.x_val = 0.1 * numpy.asarray(
             list(itertools.permutations(range(4))),
             dtype=floatX)
-        self.x_val = (numpy.ones((24, 4, 3), dtype=floatX)
-                      * self.x_val[..., None])
+        self.x_val = (numpy.ones((24, 4, 3), dtype=floatX) *
+                      self.x_val[..., None])
         self.mask_val = numpy.ones((24, 4), dtype=floatX)
         self.mask_val[12:24, 3] = 0
 

--- a/tests/datasets/test_text.py
+++ b/tests/datasets/test_text.py
@@ -36,9 +36,9 @@ def test_text():
     assert_raises(StopIteration, next, epoch)
 
     # Test character level.
-    dictionary = dict([(chr(ord('a') + i), i) for i in range(26)]
-                      + [(' ', 26)] + [('<S>', 27)]
-                      + [('</S>', 28)] + [('<UNK>', 29)])
+    dictionary = dict([(chr(ord('a') + i), i) for i in range(26)] +
+                      [(' ', 26)] + [('<S>', 27)] +
+                      [('</S>', 28)] + [('<UNK>', 29)])
     text_data = TextFile(files=[sentences1, sentences2],
                          dictionary=dictionary, preprocess=str.lower,
                          level="character")

--- a/tests/extensions/test_monitoring.py
+++ b/tests/extensions/test_monitoring.py
@@ -34,8 +34,8 @@ def test_training_data_monitoring():
 
         def before_batch(self, data):
             self.main_loop.log.current_row.true_cost = (
-                ((W.get_value() * data["features"]).sum()
-                 - data["targets"]) ** 2)
+                ((W.get_value() * data["features"]).sum() -
+                 data["targets"]) ** 2)
 
     main_loop = MainLoop(
         model=None, data_stream=dataset.get_default_stream(),


### PR DESCRIPTION
`pep8` (the PyPI package) has been updated with a new pet peeve from PEP8:

> The preferred place to break around a binary operator is after the operator, not before it.

This should fix all the occurrences we had.