### PR TITLE
Model

### DIFF
--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -205,6 +205,14 @@ class Linear(Initializable, Feedforward):
         self.input_dim = input_dim
         self.output_dim = output_dim
 
+    @property
+    def W(self):
+        return self.params[0]
+
+    @property
+    def b(self):
+        return self.params[1]
+
     def _allocate(self):
         W = shared_floatx_zeros((self.input_dim, self.output_dim), name='W')
         add_role(W, WEIGHTS)
@@ -458,8 +466,7 @@ class Sequence(Brick):
     @application(inputs=['input_'], outputs=['output'])
     def apply(self, input_):
         child_input = input_
-        for _, application_method in zip(self.children,
-                                         self.application_methods):
+        for application_method in self.application_methods:
             output = application_method(*pack(child_input))
             child_input = output
         return output

--- a/blocks/dump.py
+++ b/blocks/dump.py
@@ -73,62 +73,6 @@ def load_parameter_values(path):
     return param_values
 
 
-def extract_parameter_values(bricks):
-    """Extract parameter values from a bricks hierarchy.
-
-    Parameters
-    ----------
-    bricks : (list of) :class:`.Brick`, or :class:`.Selector`
-        The top bricks.
-
-    Returns
-    -------
-    A dictionary of (parameter name, numpy array) pairs.
-
-    """
-    if isinstance(bricks, Brick):
-        bricks = Selector([bricks])
-    if not isinstance(bricks, Selector):
-        bricks = Selector(bricks)
-    return OrderedDict([(name, variable.get_value(borrow=True))
-                        for name, variable in bricks.get_params().items()])
-
-
-def inject_parameter_values(bricks, param_values):
-    """Inject parameter values into a bricks hierarchy.
-
-    Parameters
-    ----------
-    bricks : :class:`.Brick` or :class:`.Selector or list of :class:`Brick`
-        The top bricks.
-    param_values : dict of (parameter name, :class:`~numpy.ndarray`) pairs
-        The parameter values.
-
-    """
-    if isinstance(bricks, Brick):
-        bricks = Selector([bricks])
-    if not isinstance(bricks, Selector):
-        bricks = Selector(bricks)
-
-    for name, value in param_values.items():
-        selected = bricks.select(name)
-        if len(selected) == 0:
-            logger.error("Unknown parameter {}".format(name))
-        if not len(selected) == 1:
-            raise ValueError
-        selected = selected[0]
-
-        assert selected.get_value(
-            borrow=True, return_internal_type=True).shape == value.shape
-        selected.set_value(value)
-
-    params = bricks.get_params()
-    for name in params.keys():
-        if name not in param_values:
-            logger.error("No value is provided for the parameter {}"
-                         .format(name))
-
-
 class MainLoopDumpManager(object):
     """Main loop dumping implementation.
 

--- a/blocks/dump.py
+++ b/blocks/dump.py
@@ -146,10 +146,6 @@ class MainLoopDumpManager(object):
     folder : str
         The path to the dump root folder.
 
-    Notes
-    -----
-    Requires the model to be a Brick or a list of Bricks.
-
     """
     def __init__(self, folder):
         self.folder = folder
@@ -172,7 +168,7 @@ class MainLoopDumpManager(object):
         return os.path.join(self.folder, 'log')
 
     def dump_parameters(self, main_loop):
-        save_parameter_values(extract_parameter_values(main_loop.model),
+        save_parameter_values(main_loop.model.get_param_values(),
                               self.path_to_parameters)
 
     def dump_iteration_state(self, main_loop):
@@ -216,6 +212,6 @@ class MainLoopDumpManager(object):
     def load_to(self, main_loop):
         """Loads the dump from the root folder into the main loop."""
         parameters, iteration_state, log = self.load()
-        inject_parameter_values(main_loop.model, parameters)
+        main_loop.model.set_param_values(parameters)
         main_loop.iteration_state = iteration_state
         main_loop.log = log

--- a/blocks/dump.py
+++ b/blocks/dump.py
@@ -20,13 +20,9 @@ for dumps, such as for instance .npz files.
 import logging
 import os
 import os.path
-from collections import OrderedDict
 
 import dill
 import numpy
-
-from blocks.bricks.base import Brick
-from blocks.select import Selector
 
 logger = logging.getLogger(__name__)
 
@@ -77,10 +73,9 @@ class MainLoopDumpManager(object):
     """Main loop dumping implementation.
 
     This class provides saving and loading logic that circumvents
-    serialization of the most problematic parts: the model (which is
-    typically a brick hierarchy) and the training algorithm (which
-    typically has Theano functions as attributes). The on-disk
-    representation used is a folder with a few files containing
+    serialization of the most problematic parts: the model and the training
+    algorithm (which typically has Theano functions as attributes). The
+    on-disk representation used is a folder with a few files containing
     model parameters, log and state of the data iteration.
 
     Also see the module-level documentation.

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -136,10 +136,10 @@ class MainLoop(object):
             # Sanity check: model and algorithm should be configured
             # similarly.
             if not self._model.get_objective() == self.algorithm.cost:
-                raise ValueError("different costs for model and algorithm")
+                logger.warning("different costs for model and algorithm")
             if not (set(self._model.get_params().values()) ==
                     set(self.algorithm.params)):
-                raise ValueError("different params for model and algorithm")
+                logger.warning("different params for model and algorithm")
 
         with change_recursion_limit(config.recursion_limit):
             self.original_sigint_handler = signal.signal(

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -62,22 +62,22 @@ class MainLoop(object):
 
     Parameters
     ----------
-    model : object
-        The model object. It is entirely transparent for the main loop
-        but may be used by extensions.
-    data_stream : instance of :class:`.DataStream`.
-        The data stream.
     algorithm : object
         The training algorithm.
-    log : instance of :class:`.TrainingLog`
+    data_stream : instance of :class:`.DataStream`.
+        The data stream.
+    model : :class:`.AbstractModel` instance, optional
+        The model object. It is entirely transparent for the main loop
+        but may be used by extensions.
+    log : instance of :class:`.TrainingLog`, optional
         The log. When not given, a :class:`.TrainingLog` is created.
     extensions : list of :class:`.TrainingExtension` instances
         The training extensions. Will be called in the same order as given
         here.
 
     """
-    def __init__(self, model, data_stream, algorithm,
-                 log=None, extensions=None):
+    def __init__(self, algorithm, data_stream,
+                 model=None, log=None, extensions=None):
         self.model = model
         self.data_stream = data_stream
         self.algorithm = algorithm
@@ -123,7 +123,6 @@ class MainLoop(object):
                 if not self.status._training_started:
                     for extension in self.extensions:
                         extension.main_loop = self
-                    self.algorithm.log = self.log
                     self._run_extensions('before_training')
                     self.algorithm.initialize()
                     self.status._training_started = True

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -102,7 +102,8 @@ class MainLoop(object):
     @property
     def model(self):
         if not self._model:
-            raise ValueError("no model in this main loop" + no_model_message)
+            raise AttributeError("no model in this main loop"
+                                 + no_model_message)
         return self._model
 
     @property

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -35,6 +35,11 @@ you do not want to complete this batch, press CTRL + C again. WARNING: Note \
 that this will end training immediately, and extensions that e.g. save your \
 training progress won't be run."""
 
+no_model_message = """
+
+A possible reason: one of your extensions requires the main loop to have \
+a model. Check documentation of your extensions."""
+
 
 class MainLoop(object):
     """The standard main loop of Blocks.
@@ -78,19 +83,26 @@ class MainLoop(object):
     """
     def __init__(self, algorithm, data_stream,
                  model=None, log=None, extensions=None):
-        self.model = model
-        self.data_stream = data_stream
-        self.algorithm = algorithm
-
         if not log:
             log = TrainingLog()
         if not extensions:
             extensions = []
+
+        self.data_stream = data_stream
+        self.algorithm = algorithm
         self.log = log
         self.extensions = extensions
 
+        self._model = model
+
         self.status._training_started = False
         self.status._epoch_started = False
+
+    @property
+    def model(self):
+        if not self._model:
+            raise ValueError("no model in this main loop" + no_model_message)
+        return self._model
 
     @property
     def iteration_state(self):

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -125,6 +125,9 @@ class MainLoop(object):
         a `training_finish_requested` record in the log.
 
         """
+        # This should do nothing if the user has already configured
+        # logging, and will it least enable error messages otherwise.
+        logging.basicConfig()
         with change_recursion_limit(config.recursion_limit):
             self.original_sigint_handler = signal.signal(
                 signal.SIGINT, self._handle_epoch_interrupt)

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -102,8 +102,8 @@ class MainLoop(object):
     @property
     def model(self):
         if not self._model:
-            raise AttributeError("no model in this main loop"
-                                 + no_model_message)
+            raise AttributeError("no model in this main loop" +
+                                 no_model_message)
         return self._model
 
     @property

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -1,0 +1,162 @@
+from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
+from itertools import chain
+
+from six import add_metaclass
+
+from blocks.graph import ComputationGraph
+from blocks.select import Selector
+from blocks.filter import VariableFilter, get_brick
+from blocks.roles import PARAMETER
+
+@add_metaclass(ABCMeta)
+class Model(object):
+    """A parameterized entity trained in the main loop.
+
+    A model is a parameterized entity the user trains a in a main loop.
+    The following are traits of every model:
+
+    * It has parameters and supports a way to access them. In addition
+    to returning handles to parameter objects it can return their values
+    as numpy arrays and set their values to given numpy arrays.
+
+    * It has an optimality criterion.
+
+    * It can be serialized and deserialized by mean of pickling.
+
+    * It might have bricks as its components.
+
+    This class provides an interface for models. For experiments use
+    a subclass, e.g. the :class:`DifferentiableCostModel`.
+
+    """
+
+    @abstractmethod
+    def get_params(self):
+        """Return the model parameters.
+
+        Returns
+        -------
+        params : OrderedDict
+            Dictionary of (name, parameter) pairs.
+
+        """
+        pass
+
+    def get_param_values(self):
+        """Return the values of model parameters.
+
+        The default implementation assumes that parameters are Theano
+        shared variables.
+
+        Returns
+        -------
+        param_values : OrderedDict
+            Dictionary of (parameter name, :class:`~numpy.ndarray`) pairs.
+
+        """
+        return OrderedDict((name, param.get_value())
+                           for name, param in self.get_params().items())
+
+
+    def set_param_values(self, param_values):
+        """Set the values of model parameters.
+
+        The default implementation assumes that parameters are Theano
+        shared variables.
+
+        Parameters
+        ----------
+        param_values : OrderedDict
+            Dictionary of (parameter name, :class:`~numpy.ndarray`) pairs.
+
+        """
+        params = self.get_params()
+        for name, value in param_values:
+            params[name].set_value(value)
+
+
+    @abstractmethod
+    def get_criterion(self):
+        """Return the optimization criterion."""
+        pass
+
+    @abstractmethod
+    def get_top_bricks(self):
+        """Return the top-level bricks that are used in the model.
+
+        Returns
+        -------
+        bricks : list
+            List of bricks.
+
+        """
+        pass
+
+
+class DifferentibleCostModel(Model):
+    """A model for which a differentiable Theano cost is available.
+
+    This model covers the most common case when the criterion is Theano
+    variable, the parameter are shared Theano variables. In such case
+    the parameters can be typically extracted from the computation graph,
+    as well as bricks.
+
+    The parameter names are formed from positions
+    of their owner brick in the bricks hierarchy. The variable names are
+    used for the parameters that do not belong to any brick.
+
+    Parameters
+    ----------
+    cost : `~theano.Varible`
+        The cost variable.
+
+    .. todo::
+
+        Overriding the automatically found parameters and bricks might
+        be needed.
+
+        If there top bricks in scan inner graphs, those will not be found.
+
+    """
+    def __init__(self, cost):
+        self.cost = cost
+
+        self._cg = ComputationGraph(cost)
+
+        bricks = [get_brick(var) for var in self._cg if get_brick(var)]
+        children = set(chain(*(brick.children for brick in bricks)))
+        # Quadratic complexity: we should not have thousands of
+        # top-level bricks.
+        self.top_bricks = []
+        for brick in bricks:
+            if not brick in children and not brick in self.top_bricks:
+                self.top_bricks.append(brick)
+
+        brick_param_names = {
+            v: k for k, v in Selector(self.top_bricks).get_params().items()}
+
+        self.params = []
+        for param in VariableFilter(roles=[PARAMETER])(
+                self._cg.shared_variables):
+            if param in brick_param_names:
+                self.params.append((brick_param_names[param], param))
+            else:
+                self.params.append((param.name, param))
+        self.param = OrderedDict(self.params)
+
+    def get_criterion(self):
+        return self.cost
+
+    def get_params(self):
+        """Get model parameters.
+
+        The parameter names are formed from positions of their owner bricks in
+        the bricks hierarchy. The variable names are used for the parameters
+        that do not belong to any brick.
+
+        """
+        return self.params
+
+    def get_top_bricks(self):
+        return self.top_bricks

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -127,17 +127,18 @@ class Model(AbstractModel, ComputationGraph):
     Due to frequency of this case this class is called simply 'Model'
     and not 'ComputationGraphModel'.
 
-    Parameters
-    ----------
-    outputs : (list of) :class:`~theano.Variable`
-        The output variables of the computation graph.
-
     .. todo::
 
         Overriding the automatically found parameters and bricks might
         be needed.
 
-        If there top bricks in scan inner graphs, those will not be found.
+        If there are top bricks in scan inner graphs, those will not be
+        found.
+
+    Parameters
+    ----------
+    outputs : (list of) :class:`~theano.Variable`
+        The output variables of the computation graph.
 
     """
     def __init__(self, outputs):

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -9,6 +9,7 @@ from blocks.select import Selector
 from blocks.filter import VariableFilter, get_brick
 from blocks.roles import PARAMETER
 
+
 @add_metaclass(ABCMeta)
 class Model(object):
     """A parameterized entity trained in the main loop.
@@ -30,7 +31,6 @@ class Model(object):
     a subclass, e.g. the :class:`DifferentiableCostModel`.
 
     """
-
     @abstractmethod
     def get_params(self):
         """Return the model parameters.
@@ -58,7 +58,6 @@ class Model(object):
         return OrderedDict((name, param.get_value())
                            for name, param in self.get_params().items())
 
-
     def set_param_values(self, param_values):
         """Set the values of model parameters.
 
@@ -72,9 +71,8 @@ class Model(object):
 
         """
         params = self.get_params()
-        for name, value in param_values:
+        for name, value in param_values.items():
             params[name].set_value(value)
-
 
     @abstractmethod
     def get_criterion(self):
@@ -94,7 +92,7 @@ class Model(object):
         pass
 
 
-class DifferentibleCostModel(Model):
+class DifferentiableCostModel(Model):
     """A model for which a differentiable Theano cost is available.
 
     This model covers the most common case when the criterion is Theano
@@ -130,7 +128,7 @@ class DifferentibleCostModel(Model):
         # top-level bricks.
         self.top_bricks = []
         for brick in bricks:
-            if not brick in children and not brick in self.top_bricks:
+            if brick not in children and brick not in self.top_bricks:
                 self.top_bricks.append(brick)
 
         brick_param_names = {
@@ -143,7 +141,7 @@ class DifferentibleCostModel(Model):
                 self.params.append((brick_param_names[param], param))
             else:
                 self.params.append((param.name, param))
-        self.param = OrderedDict(self.params)
+        self.params = OrderedDict(self.params)
 
     def get_criterion(self):
         return self.cost
@@ -151,9 +149,9 @@ class DifferentibleCostModel(Model):
     def get_params(self):
         """Get model parameters.
 
-        The parameter names are formed from positions of their owner bricks in
-        the bricks hierarchy. The variable names are used for the parameters
-        that do not belong to any brick.
+        The parameter names are formed from positions of their owner bricks
+        in the bricks hierarchy. The variable names are used for the
+        parameters that do not belong to any brick.
 
         """
         return self.params

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -6,6 +6,7 @@ the basic :class:`AbstractModel` interface as well as its implementations
 (currently only :class:`Model`).
 
 """
+import logging
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from itertools import chain
@@ -16,6 +17,8 @@ from blocks.graph import ComputationGraph
 from blocks.select import Selector
 from blocks.filter import VariableFilter, get_brick
 from blocks.roles import PARAMETER
+
+logger = logging.getLogger()
 
 
 @add_metaclass(ABCMeta)
@@ -79,8 +82,17 @@ class AbstractModel(object):
 
         """
         params = self.get_params()
+
+        unknown = set(param_values) - set(params)
+        missing = set(params) - set(param_values)
+        if len(unknown):
+            logger.error("unknown parameter names:\n".format(unknown))
+        if len(missing):
+            logger.error("missing values for parameters:\n".format(missing))
+
         for name, value in param_values.items():
-            params[name].set_value(value)
+            if name in params:
+                params[name].set_value(value)
 
     @abstractmethod
     def get_criterion(self):

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -20,6 +20,13 @@ from blocks.roles import PARAMETER
 
 logger = logging.getLogger()
 
+multiple_message = """
+
+Model with multiple outputs are currently only partially supported \
+in Blocks. For instance a call of 'get_objective' will crash. \
+Contact Blocks developers for more details.
+"""
+
 
 @add_metaclass(ABCMeta)
 class AbstractModel(object):
@@ -135,6 +142,8 @@ class Model(AbstractModel, ComputationGraph):
     """
     def __init__(self, outputs):
         super(Model, self).__init__(outputs)
+        if len(self.outputs) > 1:
+            logger.warning("model with multiple output " + multiple_message)
 
         bricks = [get_brick(var) for var in self if get_brick(var)]
         children = set(chain(*(brick.children for brick in bricks)))

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -32,7 +32,7 @@ class AbstractModel(object):
     to returning handles to parameter objects it can return their values
     as numpy arrays and set their values to given numpy arrays.
 
-    * It has an optimality criterion.
+    * It has an optimality objective.
 
     * It can be serialized and deserialized by mean of pickling.
 
@@ -95,8 +95,8 @@ class AbstractModel(object):
                 params[name].set_value(value)
 
     @abstractmethod
-    def get_criterion(self):
-        """Return the optimization criterion."""
+    def get_objective(self):
+        """Return the optimization objective."""
         pass
 
     @abstractmethod
@@ -156,7 +156,7 @@ class Model(AbstractModel, ComputationGraph):
                 self.params.append((param.name, param))
         self.params = OrderedDict(self.params)
 
-    def get_criterion(self):
+    def get_objective(self):
         """Return the output variable, if there is a single one.
 
         If there is only one output variable, it is a reasonable default

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -86,9 +86,9 @@ class AbstractModel(object):
         unknown = set(param_values) - set(params)
         missing = set(params) - set(param_values)
         if len(unknown):
-            logger.error("unknown parameter names:\n".format(unknown))
+            logger.error("unknown parameter names: {}\n".format(unknown))
         if len(missing):
-            logger.error("missing values for parameters:\n".format(missing))
+            logger.error("missing values for parameters: {}\n".format(missing))
 
         for name, value in param_values.items():
             if name in params:

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -144,6 +144,8 @@ class Model(AbstractModel, ComputationGraph):
         for brick in bricks:
             if brick not in children and brick not in self.top_bricks:
                 self.top_bricks.append(brick)
+        if len(set(b.name for b in self.top_bricks)) < len(self.top_bricks):
+            raise ValueError("top bricks with the same name")
 
         brick_param_names = {
             v: k for k, v in Selector(self.top_bricks).get_params().items()}

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -99,7 +99,6 @@ class AbstractModel(object):
         """Return the optimization objective."""
         pass
 
-    @abstractmethod
     def get_top_bricks(self):
         """Return the top-level bricks that are used in the model.
 
@@ -109,7 +108,7 @@ class AbstractModel(object):
             List of bricks.
 
         """
-        pass
+        raise NotImplementedError()
 
 
 class Model(AbstractModel, ComputationGraph):

--- a/examples/markov_chain/main.py
+++ b/examples/markov_chain/main.py
@@ -21,6 +21,7 @@ from blocks.datasets.streams import DataStream
 from blocks.datasets.schemes import ConstantScheme
 from blocks.algorithms import GradientDescent, Scale
 from blocks.initialization import Orthogonal, IsotropicGaussian, Constant
+from blocks.model import Model
 from blocks.monitoring import aggregation
 from blocks.extensions import FinishAfter, Printing
 from blocks.extensions.saveload import SerializeMainLoop
@@ -82,11 +83,11 @@ def main(mode, save_path, steps, num_batches):
             cost=cost, params=list(Selector(generator).get_params().values()),
             step_rule=Scale(0.001))
         main_loop = MainLoop(
-            model=generator,
+            algorithm=algorithm,
             data_stream=DataStream(
                 MarkovChainDataset(rng, seq_len),
                 iteration_scheme=ConstantScheme(batch_size)),
-            algorithm=algorithm,
+            model=Model(cost),
             extensions=[FinishAfter(after_n_batches=num_batches),
                         TrainingDataMonitoring([cost], prefix="this_step",
                                                after_every_batch=True),

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -14,6 +14,7 @@ from blocks.datasets.mnist import MNIST
 from blocks.datasets.schemes import SequentialScheme
 from blocks.filter import VariableFilter
 from blocks.graph import ComputationGraph
+from blocks.model import Model
 from blocks.monitoring import aggregation
 from blocks.extensions import FinishAfter, Timing, Printing
 from blocks.extensions.saveload import SerializeMainLoop
@@ -45,11 +46,11 @@ def main(save_to, num_epochs):
     algorithm = GradientDescent(
         cost=cost, step_rule=Scale(learning_rate=0.1))
     main_loop = MainLoop(
-        mlp,
+        algorithm,
         DataStream(mnist_train,
                    iteration_scheme=SequentialScheme(
                        mnist_train.num_examples, 50)),
-        algorithm,
+        model=Model(cost),
         extensions=[Timing(),
                     FinishAfter(after_n_epochs=num_epochs),
                     DataStreamMonitoring(

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -28,6 +28,7 @@ from blocks.datasets.schemes import ConstantScheme
 from blocks.algorithms import (GradientDescent, Scale,
                                StepClipping, CompositeRule)
 from blocks.initialization import Orthogonal, IsotropicGaussian, Constant
+from blocks.model import Model
 from blocks.monitoring import aggregation
 from blocks.extensions import FinishAfter, Printing, Timing
 from blocks.extensions.saveload import SerializeMainLoop, LoadFromDump
@@ -229,7 +230,7 @@ def main(mode, save_path, num_batches, from_dump, data_path=None):
         average_monitoring = TrainingDataMonitoring(
             observables, prefix="average", every_n_batches=10)
         main_loop = MainLoop(
-            model=bricks,
+            model=Model(cost),
             data_stream=data_stream,
             algorithm=algorithm,
             extensions=([LoadFromDump(from_dump)] if from_dump else []) +

--- a/examples/sqrt.py
+++ b/examples/sqrt.py
@@ -17,7 +17,7 @@ from blocks.algorithms import GradientDescent, Scale
 from blocks.bricks import MLP, Tanh, Identity
 from blocks.bricks.cost import SquaredError
 from blocks.initialization import IsotropicGaussian, Constant
-from blocks.model import DifferentiableCostModel
+from blocks.model import Model
 from blocks.datasets import ContainerDataset
 from blocks.datasets.streams import BatchDataStream, DataStreamMapping
 from blocks.datasets.schemes import ConstantScheme
@@ -57,10 +57,10 @@ def main(save_to, num_batches, continue_=False):
     cost.name = "cost"
 
     main_loop = MainLoop(
-        DifferentiableCostModel(cost),
-        get_data_stream(range(100)),
         GradientDescent(
             cost=cost, step_rule=Scale(learning_rate=0.001)),
+        get_data_stream(range(100)),
+        model=Model(cost),
         extensions=([LoadFromDump(save_to)] if continue_ else []) +
         [Timing(),
             FinishAfter(after_n_batches=num_batches),

--- a/examples/sqrt.py
+++ b/examples/sqrt.py
@@ -17,6 +17,7 @@ from blocks.algorithms import GradientDescent, Scale
 from blocks.bricks import MLP, Tanh, Identity
 from blocks.bricks.cost import SquaredError
 from blocks.initialization import IsotropicGaussian, Constant
+from blocks.model import DifferentiableCostModel
 from blocks.datasets import ContainerDataset
 from blocks.datasets.streams import BatchDataStream, DataStreamMapping
 from blocks.datasets.schemes import ConstantScheme
@@ -51,7 +52,7 @@ def main(save_to, num_batches, continue_=False):
     cost.name = "cost"
 
     main_loop = MainLoop(
-        mlp,
+        DifferentiableCostModel(cost),
         get_data_stream(range(100)),
         GradientDescent(
             cost=cost, step_rule=Scale(learning_rate=0.001)),

--- a/tests/scripts/test_plot.py
+++ b/tests/scripts/test_plot.py
@@ -41,11 +41,8 @@ def test_load_log():
         assert log2[0].channel0 == 0
 
     # test MainLoop pickles
-    main_loop = MainLoop(
-                    model=None,
-                    data_stream=None,
-                    algorithm=None,
-                    log=log)
+    main_loop = MainLoop(model=None, data_stream=None,
+                         algorithm=None, log=log)
 
     with tempfile.NamedTemporaryFile() as f:
         pickle_dump(main_loop, f)

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -4,7 +4,6 @@ import numpy
 import theano
 
 from examples.sqrt import main as sqrt_example
-from blocks.bricks import MLP, Identity
 from blocks.dump import (
     load_parameter_values, save_parameter_values,
     MainLoopDumpManager)

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -57,9 +57,9 @@ def test_main_loop_state_manager():
         Corrupts the iteration state!
 
         """
-        W1 = (main_loop1.model.linear_transformations[0]
+        W1 = (main_loop1.model.get_top_bricks()[0].linear_transformations[0]
                               .params[0].get_value())
-        W2 = (main_loop2.model.linear_transformations[0]
+        W2 = (main_loop2.model.get_top_bricks()[0].linear_transformations[0]
                               .params[0].get_value())
         assert numpy.all(W1 == W2)
         if check_log:

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -7,7 +7,6 @@ from examples.sqrt import main as sqrt_example
 from blocks.bricks import MLP, Identity
 from blocks.dump import (
     load_parameter_values, save_parameter_values,
-    extract_parameter_values, inject_parameter_values,
     MainLoopDumpManager)
 from tests import silence_printing
 
@@ -24,27 +23,6 @@ def test_save_load_parameter_values():
     for old, new in zip(param_values, loaded_values):
         assert old[0] == new[0]
         assert numpy.all(old[1] == new[1])
-
-
-def test_extract_parameter_values():
-    mlp = MLP([Identity(), Identity()], [10, 20, 10])
-    mlp.allocate()
-    param_values = extract_parameter_values(mlp)
-    assert len(param_values) == 4
-    assert isinstance(param_values['/mlp/linear_0.W'], numpy.ndarray)
-    assert isinstance(param_values['/mlp/linear_0.b'], numpy.ndarray)
-    assert isinstance(param_values['/mlp/linear_1.W'], numpy.ndarray)
-    assert isinstance(param_values['/mlp/linear_1.b'], numpy.ndarray)
-
-
-def test_inject_parameter_values():
-    mlp = MLP([Identity()], [10, 10])
-    mlp.allocate()
-    param_values = {'/mlp/linear_0.W': 2 * numpy.ones((10, 10), dtype=floatX),
-                    '/mlp/linear_0.b': 3 * numpy.ones(10, dtype=floatX)}
-    inject_parameter_values(mlp, param_values)
-    assert numpy.all(mlp.linear_transformations[0].params[0].get_value() == 2)
-    assert numpy.all(mlp.linear_transformations[0].params[1].get_value() == 3)
 
 
 @silence_printing

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -25,7 +25,7 @@ def test_save_load_parameter_values():
 
 
 @silence_printing
-def test_main_loop_state_manager():
+def test_main_loop_dump_manager():
     def assert_equal(main_loop1, main_loop2, check_log=True):
         """Check if two main loop objects are equal.
 

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -2,12 +2,12 @@ from six.moves import cPickle
 
 from blocks.main_loop import MainLoop
 from blocks.datasets import ContainerDataset
-from blocks.extensions import FinishAfter
+from blocks.extensions import TrainingExtension, FinishAfter
 from blocks.utils import unpack
 
 
 class MockAlgorithm(object):
-    """An algorithm that only saves data to the log.
+    """An algorithm that only saves data.
 
     Also checks that the initialization routine is only called once.
 
@@ -20,7 +20,13 @@ class MockAlgorithm(object):
         self._initialized = True
 
     def process_batch(self, batch):
-        self.log.current_row.batch = batch
+        self.batch = batch
+
+
+class WriteBatchExtension(TrainingExtension):
+    """Writes data saved by MockAlgorithm to the log."""
+    def after_batch(self, _):
+        self.main_loop.log.current_row.batch = self.main_loop.algorithm.batch
 
 
 def test_main_loop():
@@ -45,23 +51,25 @@ def test_main_loop():
     finish_extension = FinishAfter()
     finish_extension.add_condition(
         'after_epoch', predicate=lambda log: log.status.epochs_done == 2)
-    main_loop = MainLoop(None, TestDataStream(), MockAlgorithm(),
-                         None, [finish_extension])
+    main_loop = MainLoop(MockAlgorithm(), TestDataStream(),
+                         extensions=[WriteBatchExtension(),
+                                     finish_extension])
     main_loop.run()
 
     assert main_loop.log.status.iterations_done == 5
     assert main_loop.log.status._epoch_ends == [3, 5]
     assert len(list(main_loop.log)) == 7
-    for i in range(5):
-        assert main_loop.log[i].batch == dict(data=i + 1)
+    for i in range(1, 6):
+        assert main_loop.log[i].batch == dict(data=i)
 
 
 def test_training_resumption():
     def do_test(with_serialization):
         data_stream = ContainerDataset(range(10)).get_default_stream()
         main_loop = MainLoop(
-            None, data_stream, MockAlgorithm(),
-            extensions=[FinishAfter(after_n_batches=14)])
+            MockAlgorithm(), data_stream,
+            extensions=[WriteBatchExtension(),
+                        FinishAfter(after_n_batches=14)])
         main_loop.run()
         assert main_loop.log.status.iterations_done == 14
 
@@ -78,7 +86,7 @@ def test_training_resumption():
         assert main_loop.log.status.iterations_done == 27
         assert main_loop.log.status.epochs_done == 2
         for i in range(27):
-            assert main_loop.log[i].batch == {"data": i % 10}
+            assert main_loop.log[i + 1].batch == {"data": i % 10}
 
     do_test(False)
     do_test(True)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,17 +1,17 @@
 from theano import tensor
 
 from blocks.bricks import MLP, Tanh
-from blocks.model import DifferentiableCostModel
+from blocks.model import Model
 
 
-def test_differentiable_cost_model():
+def test_model():
     x = tensor.matrix('x')
     mlp1 = MLP([Tanh(), Tanh()], [10, 20, 30], name="mlp1")
     mlp2 = MLP([Tanh()], [30, 40], name="mlp2")
     h1 = mlp1.apply(x)
     h2 = mlp2.apply(h1)
 
-    model = DifferentiableCostModel(h2.sum())
+    model = Model(h2.sum())
     assert model.get_top_bricks() == [mlp1, mlp2]
     # The order of parameters returned is deterministic but
     # not sensible.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,12 @@
+import numpy
+import theano
 from theano import tensor
+from numpy.testing import assert_allclose
 
 from blocks.bricks import MLP, Tanh
 from blocks.model import Model
+
+floatX = theano.config.floatX
 
 
 def test_model():
@@ -22,3 +27,21 @@ def test_model():
         ('/mlp1/linear_0.W', mlp1.linear_transformations[0].W),
         ('/mlp1/linear_1.W', mlp1.linear_transformations[1].W),
         ('/mlp2/linear_0.W', mlp2.linear_transformations[0].W)]
+
+    # Test getting and setting parameter values
+    mlp3 = MLP([Tanh()], [10, 10])
+    mlp3.allocate()
+    model3 = Model(mlp3.apply(x))
+    param_values = {
+        '/mlp/linear_0.W': 2 * numpy.ones((10, 10), dtype=floatX),
+        '/mlp/linear_0.b': 3 * numpy.ones(10, dtype=floatX)}
+    model3.set_param_values(param_values)
+    assert numpy.all(mlp3.linear_transformations[0].params[0].get_value() == 2)
+    assert numpy.all(mlp3.linear_transformations[0].params[1].get_value() == 3)
+    got_param_values = model3.get_param_values()
+    assert len(got_param_values) == len(param_values)
+    for name, value in param_values.items():
+        assert_allclose(value, got_param_values[name])
+
+
+

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,7 @@
 import numpy
 import theano
 from theano import tensor
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_raises
 
 from blocks.bricks import MLP, Tanh
 from blocks.model import Model
@@ -42,3 +42,9 @@ def test_model():
     assert len(got_param_values) == len(param_values)
     for name, value in param_values.items():
         assert_allclose(value, got_param_values[name])
+
+    # Test name conflict handling
+    mlp4 = MLP([Tanh()], [10, 10])
+    def helper():
+        Model(mlp4.apply(mlp3.apply(x)))
+    assert_raises(ValueError, helper)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -45,6 +45,7 @@ def test_model():
 
     # Test name conflict handling
     mlp4 = MLP([Tanh()], [10, 10])
+
     def helper():
         Model(mlp4.apply(mlp3.apply(x)))
     assert_raises(ValueError, helper)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,8 @@
 from theano import tensor
 
 from blocks.bricks import MLP, Tanh
-from blocks.model import DifferentibleCostModel
+from blocks.model import DifferentiableCostModel
+
 
 def test_differentiable_cost_model():
     x = tensor.matrix('x')
@@ -10,11 +11,11 @@ def test_differentiable_cost_model():
     h1 = mlp1.apply(x)
     h2 = mlp2.apply(h1)
 
-    model = DifferentibleCostModel(h2.sum())
+    model = DifferentiableCostModel(h2.sum())
     assert model.get_top_bricks() == [mlp1, mlp2]
     # The order of parameters returned is deterministic but
     # not sensible.
-    assert list(model.get_params()) == [
+    assert list(model.get_params().items()) == [
         ('/mlp2/linear_0.b', mlp2.linear_transformations[0].b),
         ('/mlp1/linear_1.b', mlp1.linear_transformations[1].b),
         ('/mlp1/linear_0.b', mlp1.linear_transformations[0].b),

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -42,6 +42,3 @@ def test_model():
     assert len(got_param_values) == len(param_values)
     for name, value in param_values.items():
         assert_allclose(value, got_param_values[name])
-
-
-

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,23 @@
+from theano import tensor
+
+from blocks.bricks import MLP, Tanh
+from blocks.model import DifferentibleCostModel
+
+def test_differentiable_cost_model():
+    x = tensor.matrix('x')
+    mlp1 = MLP([Tanh(), Tanh()], [10, 20, 30], name="mlp1")
+    mlp2 = MLP([Tanh()], [30, 40], name="mlp2")
+    h1 = mlp1.apply(x)
+    h2 = mlp2.apply(h1)
+
+    model = DifferentibleCostModel(h2.sum())
+    assert model.get_top_bricks() == [mlp1, mlp2]
+    # The order of parameters returned is deterministic but
+    # not sensible.
+    assert list(model.get_params()) == [
+        ('/mlp2/linear_0.b', mlp2.linear_transformations[0].b),
+        ('/mlp1/linear_1.b', mlp1.linear_transformations[1].b),
+        ('/mlp1/linear_0.b', mlp1.linear_transformations[0].b),
+        ('/mlp1/linear_0.W', mlp1.linear_transformations[0].W),
+        ('/mlp1/linear_1.W', mlp1.linear_transformations[1].W),
+        ('/mlp2/linear_0.W', mlp2.linear_transformations[0].W)]


### PR DESCRIPTION
This pull request introduces a `Model` interface and its subclass `DifferentiableCostModel`. The purpose of these classes is to be passed as a `model` argument to the `MainLoop` constructor.

## Why do we need it? 

The shortest answer: because the assumption that there is always a differentiable cost is to heavy. I would not like to see it hard-coded everywhere. 

More verbosely:

* There is a need for an interface to model parameters. For instance the `Dump` extension needs them. If we let it extract them directly from the computation graph we a) can never interfere into this process b) we are bound to differentiable costs only.

* It would be nice to give extension access to the optimization criterion. That would allow very nice defaults, e.g. the `DataStreamMonitoring` in the case of a simple Theano cost could automatically add it to the list of monitored variables. 

I will answer the concern that have been already raised via email in subsequent comments.

