### PR TITLE
Installation. Again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,11 @@ before_install:
 install:
   # Install all Python dependencies
   - |
-      conda install -q --yes python=$TRAVIS_PYTHON_VERSION mkl bokeh nose numpy pip coverage six scipy
-      pip install -q --no-deps git+git://github.com/Theano/Theano.git # Development version
+      conda install -q --yes python=$TRAVIS_PYTHON_VERSION mkl bokeh nose numpy pip coverage six scipy toolz
       pip install -q nose2[coverage-plugin] coveralls
 script:
   - |
-      python setup.py install # Tests setup.py (should also install dill)
+      pip install . -r requirements.txt # Tests setup.py (should also install dill)
       # Must export environment variable so that the subprocess is aware of it
       export THEANO_FLAGS=floatX=$TESTS,optimizer=fast_compile
       # Running nose2 within coverage makes imports count towards coverage

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -7,35 +7,37 @@ directly from GitHub.
 
 .. code-block:: bash
 
-   $ pip install --process-dependency-links --upgrade git+git://github.com/bartvm/blocks.git#egg=blocks
+   $ pip install git+git://github.com/bartvm/blocks.git \
+     -r https://raw.githubusercontent.com/bartvm/blocks/master/requirements.txt
 
 .. note::
 
-   Blocks relies on `picklable_itertools`_, a library which is not listed
-   on the Python Package Index (PyPI) yet, so it must be installed directly
-   from GitHub. Pip only does this when the ``--process-dependency-links``
-   argument is passed.
+   Blocks relies on several packages, such as Theano_ and picklable_itertools_,
+   to be installed directly from GitHub. The only way of doing so reliably is
+   through a ``requirements.txt`` file, which is why this installation command
+   might look slightly different from what you're used to.
 
 If you want to make sure that you can use the plotting integration with Bokeh_,
-install that extra requirements as well.
+run this command after installing the main framework.
 
 .. code-block:: bash
 
-   $ pip install --process-dependency-links --upgrade git+git://github.com/bartvm/blocks.git#egg=blocks[plot]
+   $ pip install git+git://github.com/bartvm/blocks.git#egg=blocks[plot]
 
 If you don't have administrative rights, add the ``--user`` switch to the
-install command to install the package in your home folder. If you want to
-update Blocks, simply repeat one of the commands above to pull the latest
-version from GitHub.
+install commands to install the packages in your home folder. If you want to
+update Blocks, simply repeat the first command with the ``--upgrade`` switch
+added to pull the latest version from GitHub.
 
 .. warning::
 
-   Pip may try to update your versions of NumPy and SciPy if they are outdated.
-   However, pip's versions might not be linked to an optimized BLAS
-   implementation. To prevent this from happening use the ``--no-deps`` flag
-   when installing Blocks and install the dependencies manually, making sure
-   that you install NumPy and SciPy using your system's package manager (e.g.
-   ``apt-get`` or ``yum``), or use a Python distribution like Anaconda_.
+   Pip may try to install or update NumPy and SciPy if they are not present or
+   outdated. However, pip's versions might not be linked to an optimized BLAS
+   implementation. To prevent this from happening make sure you update NumPy
+   and SciPy using your system's package manager (e.g.  ``apt-get`` or
+   ``yum``), or use a Python distribution like Anaconda_, before installing
+   Blocks. You can also pass the ``--no-deps`` switch and install all the
+   requirements manually.
 
 .. _picklable_itertools: https://github.com/dwf/picklable_itertools
 
@@ -53,7 +55,7 @@ training progress.
 
 We develop using the bleeding-edge version of Theano, so be sure to follow the
 `relevant installation instructions`_ to make sure that your Theano version is
-up to date.
+up to date if you didn't install it through Blocks.
 
 .. _Anaconda: https://store.continuum.io/cshop/anaconda/
 .. _nose2: https://nose2.readthedocs.org/en/latest/
@@ -74,7 +76,8 @@ with your own GitHub user name:
 
 .. code-block:: bash
 
-   $ pip install --upgrade -e git+git@github.com:USER/blocks.git#egg=blocks[test,plot,docs] --src=$HOME
+   $ pip install -e git+git://github.com/USER/blocks.git#egg=blocks[test,plot,docs] --src=$HOME \
+     -r https://raw.githubusercontent.com/bartvm/blocks/install_again/requirements.txt
 
 As with the usual installation, you can use ``--user`` or ``--no-deps`` if you
 need to. You can now make changes in the ``blocks`` directory created by pip,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+--allow-external picklable-itertools
+--allow-unverified picklable-itertools
+git+https://github.com/dwf/picklable_itertools.git#egg=picklable-itertools
+
+--allow-external theano
+--allow-unverified theano
+git+https://github.com/Theano/Theano.git#egg=theano

--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,11 @@ setup(
     packages=find_packages(exclude=['examples', 'docs', 'tests']),
     scripts=['bin/blocks-continue', 'bin/blocks-dump'],
     setup_requires=['numpy'],
-    install_requires=['dill', 'numpy', 'theano', 'six', 'pyyaml', 'pandas',
-                      'picklable_itertools', 'toolz'],
+    install_requires=['dill', 'numpy', 'six', 'pyyaml', 'pandas', 'toolz',
+                      'theano', 'picklable-itertools'],
     extras_require={
         'test': ['nose', 'nose2'],
         'plot': ['bokeh'],
         'docs': ['sphinx', 'sphinxcontrib-napoleon', 'sphinx-rtd-theme']
     },
-    dependency_links=['http://github.com/dwf/picklable_itertools/'
-                      'tarball/master#egg=picklable_itertools'],
     zip_safe=False)


### PR DESCRIPTION
So installation through `pip` is a real nightmare if you have dependencies on packages that are only on GitHub. The `dependency_links` argument is deprecated and requires you to pass the `--process-dependency-links` (which was nearly removed in pip 1.6), and results in a long list of warnings and errors that you are using deprecated features and downloading from insecure sources...

See [this](https://caremad.io/2013/07/setup-vs-requirement/) for a long overview, but apparently the correct way to specify these dependencies is through a `requirements.txt` file. Although this means that we use a slightly different `pip install` command, it actually works like a charm. It automatically installs the latest version of Theano and `picklable_itertools` from GitHub without warnings while keeping the `setup.py` file looking the way it should.