### PR TITLE
Skip tests if optional requirements are not met. Fixes #170.

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,10 +1,14 @@
 import logging
+import os
 import sys
 from functools import wraps
+from importlib import import_module
+from unittest.case import SkipTest
 
 from six import StringIO
 
 import blocks
+from blocks import config
 
 
 def silence_printing(test):
@@ -21,3 +25,40 @@ def silence_printing(test):
             sys.stdout = stdout
             logger.setLevel(old_level)
     return wrapper
+
+
+def skip_if_not_available(modules=None, datasets=None, configurations=None):
+    """Raises a SkipTest exception when requirements are not met.
+
+    Parameters
+    ----------
+    modules : list
+        A list of strings of module names. If one of the modules fails to
+        import, the test will be skipped.
+    datasets : list
+        A list of strings of folder names. If the data path is not
+        configured, or the folder does not exist, the test is skipped.
+    configurations : list
+        A list of of strings of configuration names. If this configuration
+        is not set and does not have a default, the test will be skipped.
+
+    """
+    if modules is None:
+        modules = []
+    if datasets is None:
+        datasets = []
+    if configurations is None:
+        configurations = []
+    for module in modules:
+        try:
+            import_module(module)
+        except Exception:
+            raise SkipTest
+    if datasets and not hasattr(config, 'data_path'):
+        raise SkipTest
+    for dataset in datasets:
+        if not os.path.exists(os.path.join(config.data_path, dataset)):
+            raise SkipTest
+    for configuration in configurations:
+        if not hasattr(config, configuration):
+            raise SkipTest

--- a/tests/datasets/test_mnist.py
+++ b/tests/datasets/test_mnist.py
@@ -4,9 +4,11 @@ from numpy.testing import assert_raises
 import theano
 
 from blocks.datasets.mnist import MNIST
+from tests import skip_if_not_available
 
 
 def test_mnist():
+    skip_if_not_available(datasets=['mnist'])
     mnist_train = MNIST('train', start=20000)
     assert len(mnist_train.features) == 40000
     assert len(mnist_train.targets) == 40000

--- a/tests/datasets/test_serialization.py
+++ b/tests/datasets/test_serialization.py
@@ -7,9 +7,11 @@ import numpy
 from blocks.datasets.streams import DataStream
 from blocks.datasets.mnist import MNIST
 from blocks.datasets.schemes import SequentialScheme
+from tests import skip_if_not_available
 
 
 def test_in_memory():
+    skip_if_not_available(datasets=['mnist'])
     # Load MNIST and get two batches
     mnist = MNIST('train')
     data_stream = DataStream(mnist, iteration_scheme=SequentialScheme(

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -8,9 +8,13 @@ import pkgutil
 
 import blocks
 import blocks.bricks
+from tests import skip_if_not_available
 
 
 def setup(testobj):
+    skip_if_not_available(modules=['nose2'])
+    if testobj.name == 'blocks.datasets.InMemoryDataset':
+        skip_if_not_available(datasets=['mnist'])
     # Not importing unicode_literal because it gives problems
     # If needed, see https://dirkjan.ochtman.nl/writing/2014/07/06/
     # single-source-python-23-doctests.html for a solution
@@ -19,6 +23,7 @@ def setup(testobj):
 
 
 def load_tests(loader, tests, ignore):
+
     # This function loads doctests from all submodules and runs them
     # with the __future__ imports necessary for Python 2
     for _, module, _ in pkgutil.walk_packages(path=blocks.__path__,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,7 +9,7 @@ from examples.sqrt import main as sqrt_test
 from examples.mnist import main as mnist_test
 from examples.markov_chain.main import main as markov_chain_test
 from examples.reverse_words import main as reverse_words_test
-from tests import silence_printing
+from tests import silence_printing, skip_if_not_available
 
 
 @silence_printing
@@ -22,6 +22,7 @@ def test_sqrt():
 
 @silence_printing
 def test_mnist():
+    skip_if_not_available(modules=['bokeh'])
     with tempfile.NamedTemporaryFile() as f:
         mnist_test(f.name, 1)
         with open(f.name, "rb") as source:
@@ -40,6 +41,7 @@ def test_markov_chain():
 
 @silence_printing
 def test_reverse_words():
+    skip_if_not_available(modules=['bokeh'])
     old_limit = blocks.config.recursion_limit
     blocks.config.recursion_limit = 100000
     with tempfile.NamedTemporaryFile() as f_save,\


### PR DESCRIPTION
Title says it all: Wrote a function that allows tests to be skipped when optional modules aren't installed, datasets aren't there, or if a certain configuration isn't set. Skipping doctests this way is also possible by setting the conditions in the `test_doctest.py`file.