### PR TITLE
WIP: Refactoring Attention

### DIFF
--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -131,7 +131,8 @@ class Initializable(Brick):
         if getattr(self, '_rng', None) is not None:
             return self._rng
         else:
-            return numpy.random.RandomState(self.seed)
+            self._rng = numpy.random.RandomState(self.seed)
+            return self._rng
 
     @rng.setter
     def rng(self, rng):

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -88,7 +88,7 @@ class SequenceContentAttention(Initializable):
         if not sequence_transformer:
             sequence_transformer = MLP([Identity()], name="seq_trans")
         if not energy_computer:
-            energy_computer = EnergyComputer(name="energy_comp")
+            energy_computer = ShallowEnergyComputer(name="energy_comp")
         self.sequence_transformer = sequence_transformer
         self.energy_computer = energy_computer
 
@@ -182,10 +182,11 @@ class SequenceContentAttention(Initializable):
         return super(SequenceContentAttention, self).get_dim(name)
 
 
-class EnergyComputer(Sequence, Initializable, Feedforward):
+class ShallowEnergyComputer(Sequence, Initializable, Feedforward):
+    """A simple energy computer: First tanh, then weighted sum."""
     @lazy
     def __init__(self, **kwargs):
-        super(EnergyComputer, self).__init__(
+        super(ShallowEnergyComputer, self).__init__(
             [Tanh().apply, MLP([Identity()]).apply], **kwargs)
 
     @property

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -428,7 +428,7 @@ class AttentionRecurrent(AbstractAttentionRecurrent, Initializable):
             attended_mask_name = self.context_names[1]
         if not distribute:
             normal_inputs = [name for name in self.sequence_names
-                             if not 'mask' in name]
+                             if 'mask' not in name]
             distribute = Distribute(normal_inputs,
                                     attention.take_look.outputs[0])
 

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -589,6 +589,6 @@ class SequenceGenerator(BaseSequenceGenerator):
                 add_contexts=add_contexts, name="att_trans")
         else:
             transition = FakeAttentionRecurrent(transition,
-                                                 name="with_fake_attention")
+                                                name="with_fake_attention")
         super(SequenceGenerator, self).__init__(
             readout, transition, fork, **kwargs)

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -6,11 +6,12 @@ from theano import tensor
 
 from blocks.bricks import Initializable, Identity, MLP, Random
 from blocks.bricks.base import application, Brick, lazy
-from blocks.bricks.recurrent import BaseRecurrent
 from blocks.bricks.parallel import Fork, Distribute
 from blocks.bricks.lookup import LookupTable
 from blocks.bricks.recurrent import recurrent
-from blocks.utils import dict_subset, dict_union
+from blocks.bricks.attention import (
+    AbstractAttentionRecurrent, AttentionRecurrent)
+from blocks.utils import dict_union
 
 
 class BaseSequenceGenerator(Initializable):
@@ -82,7 +83,7 @@ class BaseSequenceGenerator(Initializable):
     ----------
     readout : instance of :class:`AbstractReadout`
         The readout component of the sequence generator.
-    transition : instance of :class:`AbstractAttentionTransition`
+    transition : instance of :class:`AbstractAttentionRecurrent`
         The transition component of the sequence generator.
     fork : :class:`.Brick`
         The brick to compute the transition's inputs from the feedback.
@@ -501,229 +502,7 @@ class LookupFeedback(AbstractFeedback, Initializable):
         return super(LookupFeedback, self).get_dim(name)
 
 
-class AttentionTransition(AbstractAttentionTransition, Initializable):
-    """Combines an attention mechanism and a recurrent transition.
-
-    This brick is assembled from three components: an attention mechanism,
-    a recurrent transition and a brick to make the first two work
-    together.  It is expected that among the contexts of the transition's
-    `apply` methods there is one, intended to be attended by the attention
-    mechanism, and another one serving as a mask for the first one.
-
-    Parameters
-    ----------
-    transition : :class:`.Brick`
-        The recurrent transition.
-    attention : :class:`.Brick`
-        The attention mechanism.
-    attended_name : str
-        The name of the attended context. If ``None``, the first context is
-        used.
-    attended_mask_name : str
-        The name of the mask for the attended context. If ``None``, the
-        second context is used.
-
-    Notes
-    -----
-    See :class:`.Initializable` for initialization parameters.
-
-    Currently lazy-only.
-
-    """
-    def __init__(self, transition, attention, distribute,
-                 attended_name=None, attended_mask_name=None,
-                 **kwargs):
-        super(AttentionTransition, self).__init__(**kwargs)
-        self.transition = transition
-        self.attention = attention
-        self.distribute = distribute
-
-        self.sequence_names = self.transition.apply.sequences
-        self.state_names = self.transition.apply.states
-        self.context_names = self.transition.apply.contexts
-
-        if not attended_name:
-            attended_name = self.context_names[0]
-        if not attended_mask_name:
-            attended_mask_name = self.context_names[1]
-        self.attended_name = attended_name
-        self.attended_mask_name = attended_mask_name
-
-        self.preprocessed_attended_name = "preprocessed_" + self.attended_name
-
-        self.glimpse_names = self.attention.take_look.outputs
-        # We need to determine which glimpses are fed back.
-        # Currently we extract it from `take_look` signature.
-        self.previous_glimpses_needed = [
-            name for name in self.glimpse_names
-            if name in self.attention.take_look.inputs]
-
-        self.children = [self.transition, self.attention, self.distribute]
-
-    def _push_allocation_config(self):
-        self.attention.state_dims = self.transition.get_dims(self.state_names)
-        self.attention.sequence_dim = self.transition.get_dim(
-            self.attended_name)
-        self.distribute.target_dims = dict_subset(
-            dict_union(
-                self.transition.get_dims(self.sequence_names)),
-            self.distribute.target_names)
-        self.distribute.source_dim = self.attention.get_dim(
-            self.distribute.source_name)
-
-    @application
-    def take_look(self, **kwargs):
-        r"""Compute glimpses with the attention mechanism.
-
-        Parameters
-        ----------
-        \*\*kwargs
-            Should contain contexts, previous step states and glimpses.
-
-        Returns
-        -------
-        glimpses : list of :class:`~tensor.TensorVariable`
-            Current step glimpses.
-
-        """
-        return self.attention.take_look(
-            kwargs[self.attended_name],
-            kwargs.get(self.preprocessed_attended_name),
-            mask=kwargs.get("mask"),
-            **dict_subset(kwargs,
-                          self.state_names + self.previous_glimpses_needed))
-
-    @take_look.property('outputs')
-    def take_look_outputs(self):
-        return self.glimpse_names
-
-    @application
-    def compute_states(self, **kwargs):
-        r"""Compute current states when glimpses have already been computed.
-
-        Parameters
-        ----------
-        \*\*kwargs
-            Should contain everything what `self.transition` needs
-            and in addition current glimpses.
-
-        Returns
-        -------
-        current_states : list of :class:`~tensor.TensorVariable`
-            Current states computed by `self.transition`.
-
-        """
-        sequences = dict_subset(kwargs, self.sequence_names, pop=True,
-                                must_have=False)
-        states = dict_subset(kwargs, self.state_names, pop=True)
-        glimpses = dict_subset(kwargs, self.glimpse_names, pop=True)
-        sequences.update(self.distribute.apply(
-            return_dict=True,
-            **dict_subset(dict_union(sequences, glimpses),
-                          self.distribute.apply.inputs)))
-        current_states = self.transition.apply(
-            iterate=False, return_list=True,
-            **dict_union(sequences, states, kwargs))
-        return current_states
-
-    @compute_states.property('outputs')
-    def compute_states_outputs(self):
-        return self.state_names
-
-    @recurrent
-    def do_apply(self, **kwargs):
-        r"""Process a sequence attending the attended context every step.
-
-        Parameters
-        ----------
-        \*\*kwargs
-            Should contain current inputs, previous step states, contexts,
-            the preprocessed attended context, previous step glimpses.
-
-        Returns
-        -------
-        outputs : list of :class:`~tensor.TensorVariable`
-            The current step states and glimpses.
-
-        """
-        attended = kwargs[self.attended_name]
-        preprocessed_attended = kwargs.pop(self.preprocessed_attended_name)
-        attended_mask = kwargs.get(self.attended_mask_name)
-
-        sequences = dict_subset(kwargs, self.sequence_names, pop=True,
-                                must_have=False)
-        states = dict_subset(kwargs, self.state_names, pop=True)
-        glimpses = dict_subset(kwargs, self.glimpse_names, pop=True)
-
-        current_glimpses = self.take_look(
-            mask=attended_mask, return_dict=True,
-            **dict_union(
-                states, glimpses,
-                {self.attended_name: attended,
-                 self.preprocessed_attended_name: preprocessed_attended}))
-        current_states = self.compute_states(
-            return_list=True,
-            **dict_union(sequences, states, current_glimpses, kwargs))
-        return current_states + list(current_glimpses.values())
-
-    @do_apply.property('sequences')
-    def do_apply_sequences(self):
-        return self.transition.apply.sequences
-
-    @do_apply.property('contexts')
-    def do_apply_contexts(self):
-        return self.transition.apply.contexts + [
-            self.preprocessed_attended_name]
-
-    @do_apply.property('states')
-    def do_apply_states(self):
-        return self.transition.apply.states + self.glimpse_names
-
-    @do_apply.property('outputs')
-    def do_apply_outputs(self):
-        return self.transition.apply.states + self.glimpse_names
-
-    @application
-    def apply(self, **kwargs):
-        """Preprocess a sequence attending the attended context at every step.
-
-        Preprocesses the attended context and runs :meth:`do_apply`. See
-        :meth:`do_apply` documentation for further information.
-
-        """
-        preprocessed_attended = self.attention.preprocess(
-            kwargs[self.attended_name])
-        return self.do_apply(
-            **dict_union(kwargs,
-                         {self.preprocessed_attended_name:
-                          preprocessed_attended}))
-
-    @apply.delegate
-    def apply_delegate(self):
-        # TODO: Nice interface for this trick?
-        return self.do_apply.__get__(self, None)
-
-    @apply.property('contexts')
-    def apply_contexts(self):
-        return self.transition.apply.contexts
-
-    @application
-    def initial_state(self, state_name, batch_size, **kwargs):
-        if state_name in self.glimpse_names:
-            return self.attention.initial_glimpses(
-                state_name, batch_size, kwargs[self.attended_name])
-        return self.transition.initial_state(state_name, batch_size, **kwargs)
-
-    def get_dim(self, name):
-        if name in self.glimpse_names:
-            return self.attention.get_dim(name)
-        if name == self.preprocessed_attended_name:
-            (original_name,) = self.attention.preprocess.outputs
-            return self.attention.get_dim(original_name)
-        return self.transition.get_dim(name)
-
-
-class FakeAttentionTransition(AbstractAttentionTransition, Initializable):
+class FakeAttentionRecurrent(AbstractAttentionRecurrent, Initializable):
     """Adds fake attention interface to a transition.
 
     Notes
@@ -733,7 +512,7 @@ class FakeAttentionTransition(AbstractAttentionTransition, Initializable):
 
     """
     def __init__(self, transition, **kwargs):
-        super(FakeAttentionTransition, self).__init__(**kwargs)
+        super(FakeAttentionRecurrent, self).__init__(**kwargs)
         self.transition = transition
 
         self.state_names = transition.apply.states
@@ -801,10 +580,10 @@ class SequenceGenerator(BaseSequenceGenerator):
         if attention:
             distribute = Distribute(fork_inputs,
                                     attention.take_look.outputs[0])
-            transition = AttentionTransition(transition, attention, distribute,
+            transition = AttentionRecurrent(transition, attention, distribute,
                                              name="att_trans")
         else:
-            transition = FakeAttentionTransition(transition,
+            transition = FakeAttentionRecurrent(transition,
                                                  name="with_fake_attention")
         super(SequenceGenerator, self).__init__(
             readout, transition, fork, **kwargs)

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -563,6 +563,10 @@ class SequenceGenerator(BaseSequenceGenerator):
     attention : :class:`.Brick`
         The attention mechanism to be added to ``transition``. Can be
         ``None``, in which case no attention mechanism is used.
+    add_contexts : bool
+        If ``True``, the :class:`AttentionRecurrent` wrapping the
+        `transition` will add additional contexts for the attended and
+        its mask.
 
     Notes
     -----
@@ -571,7 +575,7 @@ class SequenceGenerator(BaseSequenceGenerator):
 
     """
     def __init__(self, readout, transition, attention=None,
-                 fork_inputs=None, **kwargs):
+                 fork_inputs=None, add_contexts=True, **kwargs):
         if not fork_inputs:
             fork_inputs = [name for name in transition.apply.sequences
                            if name != 'mask']
@@ -580,8 +584,9 @@ class SequenceGenerator(BaseSequenceGenerator):
         if attention:
             distribute = Distribute(fork_inputs,
                                     attention.take_look.outputs[0])
-            transition = AttentionRecurrent(transition, attention, distribute,
-                                             name="att_trans")
+            transition = AttentionRecurrent(
+                transition, attention, distribute,
+                add_contexts=add_contexts, name="att_trans")
         else:
             transition = FakeAttentionRecurrent(transition,
                                                  name="with_fake_attention")

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -286,26 +286,6 @@ class AbstractReadout(AbstractEmitter, AbstractFeedback):
 
 
 @add_metaclass(ABCMeta)
-class AbstractAttentionTransition(BaseRecurrent):
-    """A base class for a transition component of a sequence generator.
-
-    A recurrent transition combined with an attention mechanism.
-
-    """
-    @abstractmethod
-    def apply(self, **kwargs):
-        pass
-
-    @abstractmethod
-    def compute_states(self, **kwargs):
-        pass
-
-    @abstractmethod
-    def take_look(self, **kwargs):
-        pass
-
-
-@add_metaclass(ABCMeta)
 class Readout(AbstractReadout):
     """Readout brick with separated emitting and feedback parts.
 

--- a/blocks/utils.py
+++ b/blocks/utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import contextlib
 from collections import OrderedDict
@@ -371,8 +372,8 @@ def repr_attrs(instance, *attrs):
         return orig_repr_template.format(instance, id(instance))
 
 
-def put_hook(variable, hook_fn):
-    """Put a hook on a Theano variables.
+def put_hook(variable, hook_fn, *args):
+    r"""Put a hook on a Theano variables.
 
     Ensures that the hook function is executed every time when the value
     of the Theano variable is available.
@@ -384,9 +385,11 @@ def put_hook(variable, hook_fn):
     hook_fn : function
         The hook function. Should take a single argument: the variable's
         value.
+    *args : list
+        Positional arguments to pass to the hook function.
 
     """
-    return printing.Print(global_fn=lambda _, x: hook_fn(x))(variable)
+    return printing.Print(global_fn=lambda _, x: hook_fn(x, *args))(variable)
 
 
 def ipdb_breakpoint(x):
@@ -400,6 +403,12 @@ def ipdb_breakpoint(x):
     """
     import ipdb
     ipdb.set_trace()
+
+
+def print_sum(x, header=None):
+    if not header:
+        header = 'print_sum'
+    print(header + ':', x.sum())
 
 
 @contextlib.contextmanager

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -167,7 +167,7 @@ def main(mode, save_path, num_batches, from_dump, data_path=None):
         generator = SequenceGenerator(
             readout=readout, transition=transition, attention=attention,
             weights_init=IsotropicGaussian(0.1), biases_init=Constant(0),
-            name="generator")
+            add_contexts=False, name="generator")
         generator.push_initialization_config()
         transition.weights_init = Orthogonal()
         generator.initialize()

--- a/tests/bricks/test_attention.py
+++ b/tests/bricks/test_attention.py
@@ -127,5 +127,5 @@ def test_attention_recurrent():
 
     # freeze sums
     assert_allclose(weight_vals.sum(), input_length * batch_size, 1e-5)
-    assert_allclose(states_vals.sum(), 117.116, rtol=1e-5)
-    assert_allclose(glimpses_vals.sum(), 404.272, rtol=1e-5)
+    assert_allclose(states_vals.sum(), 113.429, rtol=1e-5)
+    assert_allclose(glimpses_vals.sum(), 415.901, rtol=1e-5)

--- a/tests/bricks/test_attention.py
+++ b/tests/bricks/test_attention.py
@@ -32,8 +32,8 @@ def test_sequence_content_attention():
     sequences = tensor.tensor3('sequences')
     states = tensor.matrix('states')
     mask = tensor.matrix('mask')
-    glimpses, weights = attention.take_look(sequences, states=states,
-                                            mask=mask)
+    glimpses, weights = attention.take_glimpses(sequences, states=states,
+                                                mask=mask)
     assert glimpses.ndim == 2
     assert weights.ndim == 2
 

--- a/tests/bricks/test_attention.py
+++ b/tests/bricks/test_attention.py
@@ -68,8 +68,7 @@ def test_attention_recurrent():
     attention = SequenceContentAttention(
         state_names=wrapped.apply.states,
         sequence_dim=attended_dim, match_dim=attended_dim)
-    recurrent = AttentionRecurrent(wrapped, attention)
-    recurrent.rng = rng
+    recurrent = AttentionRecurrent(wrapped, attention, seed=1234)
     recurrent.weights_init = IsotropicGaussian(0.5)
     recurrent.biases_init = Constant(0)
     recurrent.initialize()

--- a/tests/bricks/test_attention.py
+++ b/tests/bricks/test_attention.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_allclose
 import theano
 from theano import tensor
 
-from blocks import config
 from blocks.bricks.attention import (
     SequenceContentAttention, AttentionRecurrent)
 from blocks.bricks.recurrent import SimpleRecurrent

--- a/tests/bricks/test_attention.py
+++ b/tests/bricks/test_attention.py
@@ -1,9 +1,13 @@
 import numpy
+from numpy.testing import assert_allclose
 
 import theano
 from theano import tensor
 
-from blocks.bricks.attention import SequenceContentAttention
+from blocks.bricks.attention import (
+    SequenceContentAttention, AttentionRecurrent)
+from blocks.bricks.recurrent import SimpleRecurrent
+from blocks.initialization import IsotropicGaussian, Constant
 
 floatX = theano.config.floatX
 
@@ -46,3 +50,72 @@ def test_sequence_content_attention():
     assert numpy.all(weight_values <= 1)
     assert numpy.all(weight_values.sum(axis=1) == 1)
     assert numpy.all((weight_values.T == 0) == (mask_values == 0))
+
+
+def test_attention_recurrent():
+    dim = 5
+    batch_size = 4
+    input_length = 20
+
+    attended_dim = 10
+    attended_length = 15
+
+    wrapped = SimpleRecurrent(dim)
+    attention = SequenceContentAttention(
+        state_names=wrapped.apply.states, match_dim=attended_dim)
+    recurrent = AttentionRecurrent(
+        wrapped, attention, attended_dim=attended_dim)
+    recurrent.weights_init = IsotropicGaussian(0.5)
+    recurrent.biases_init = Constant(0)
+    recurrent.initialize()
+
+    attended = tensor.tensor3("attended")
+    attended_mask = tensor.matrix("attended_mask")
+    inputs = tensor.tensor3("inputs")
+    inputs_mask = tensor.matrix("inputs_mask")
+    states, glimpses, weights = recurrent.apply(
+        inputs=inputs, mask=inputs_mask,
+        attended=attended, attended_mask=attended_mask)
+    assert states.ndim == 3
+    assert glimpses.ndim == 3
+    assert weights.ndim == 3
+
+    # For values.
+    rng = numpy.random.RandomState(1234)
+    rand = lambda size: rng.uniform(size=size).astype(floatX)
+
+    # For masks.
+    def generate_mask(length, batch_size):
+        mask = numpy.ones((length, batch_size), dtype=floatX)
+        # To make it look like read data
+        for i in range(batch_size):
+            mask[1 + rng.randint(0, length - 1):, i] = 0.0
+        return mask
+
+    input_vals = rand((input_length, batch_size, dim))
+    input_mask_vals = generate_mask(input_length, batch_size)
+    attended_vals = rand((attended_length, batch_size, attended_dim))
+    attended_mask_vals = generate_mask(attended_length, batch_size)
+
+    func = theano.function([inputs, inputs_mask, attended, attended_mask],
+                           [states, glimpses, weights])
+    states_vals, glimpses_vals, weight_vals = func(
+        input_vals, input_mask_vals,
+        attended_vals, attended_mask_vals)
+
+    # weights for not masked position must be zero
+    assert numpy.all(weight_vals * (1 - attended_mask_vals.T) == 0)
+    # weights for masked positions must be non-zero
+    assert numpy.all(abs(weight_vals + (1 - attended_mask_vals.T)) > 1e-5)
+    # weights from different steps should be noticeably different
+    assert (abs(weight_vals[0] - weight_vals[1])).sum() > 1e-2
+    # weights for all state after the last masked position should be same
+    for i in range(batch_size):
+        last = int(input_mask_vals[:, i].sum())
+        for j in range(last, input_length):
+            assert_allclose(weight_vals[last, i], weight_vals[j, i])
+
+    # freeze sums
+    assert_allclose(weight_vals.sum(), input_length * batch_size, 1e-5)
+    assert_allclose(states_vals.sum(), 68.112, rtol=1e-5)
+    assert_allclose(glimpses_vals.sum(), 416.316, rtol=1e-5)

--- a/tests/bricks/test_attention.py
+++ b/tests/bricks/test_attention.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_allclose
 import theano
 from theano import tensor
 
+from blocks import config
 from blocks.bricks.attention import (
     SequenceContentAttention, AttentionRecurrent)
 from blocks.bricks.recurrent import SimpleRecurrent
@@ -55,6 +56,8 @@ def test_sequence_content_attention():
 
 
 def test_attention_recurrent():
+    rng = numpy.random.RandomState(1234)
+
     dim = 5
     batch_size = 4
     input_length = 20
@@ -67,6 +70,7 @@ def test_attention_recurrent():
         state_names=wrapped.apply.states,
         sequence_dim=attended_dim, match_dim=attended_dim)
     recurrent = AttentionRecurrent(wrapped, attention)
+    recurrent.rng = rng
     recurrent.weights_init = IsotropicGaussian(0.5)
     recurrent.biases_init = Constant(0)
     recurrent.initialize()
@@ -84,7 +88,6 @@ def test_attention_recurrent():
     assert weights.ndim == 3
 
     # For values.
-    rng = numpy.random.RandomState(1234)
     rand = lambda size: rng.uniform(size=size).astype(floatX)
 
     # For masks.
@@ -125,5 +128,5 @@ def test_attention_recurrent():
 
     # freeze sums
     assert_allclose(weight_vals.sum(), input_length * batch_size, 1e-5)
-    assert_allclose(states_vals.sum(), 69.313, rtol=1e-5)
-    assert_allclose(glimpses_vals.sum(), 424.26, rtol=1e-5)
+    assert_allclose(states_vals.sum(), 117.116, rtol=1e-5)
+    assert_allclose(glimpses_vals.sum(), 404.272, rtol=1e-5)

--- a/tests/bricks/test_attention.py
+++ b/tests/bricks/test_attention.py
@@ -87,7 +87,8 @@ def test_attention_recurrent():
     assert weights.ndim == 3
 
     # For values.
-    rand = lambda size: rng.uniform(size=size).astype(floatX)
+    def rand(size):
+        return rng.uniform(size=size).astype(floatX)
 
     # For masks.
     def generate_mask(length, batch_size):

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -353,6 +353,7 @@ def test_mlp():
     mlp.initialize()
     assert_allclose(x_val.dot(numpy.ones((16, 8))),
                     y.eval({x: x_val}), rtol=1e-06)
+    assert mlp.rng == mlp.linear_transformations[0].rng
 
 
 def test_sequence():

--- a/tests/bricks/test_recurrent.py
+++ b/tests/bricks/test_recurrent.py
@@ -205,12 +205,15 @@ class TestBidirectional(unittest.TestCase):
     def setUp(self):
         self.bidir = Bidirectional(weights_init=Orthogonal(),
                                    prototype=SimpleRecurrent(
-                                       dim=3, activation=Tanh()),
-                                   seed=1)
+                                       dim=3, activation=Tanh()))
         self.simple = SimpleRecurrent(dim=3, weights_init=Orthogonal(),
                                       activation=Tanh(), seed=1)
-        self.bidir.initialize()
+        self.bidir.allocate()
         self.simple.initialize()
+        self.bidir.children[0].params[0].set_value(
+            self.simple.params[0].get_value())
+        self.bidir.children[1].params[0].set_value(
+            self.simple.params[0].get_value())
         self.x_val = 0.1 * numpy.asarray(
             list(itertools.permutations(range(4))),
             dtype=floatX)

--- a/tests/bricks/test_sequence_generators.py
+++ b/tests/bricks/test_sequence_generators.py
@@ -7,10 +7,11 @@ from blocks.bricks import Tanh
 from blocks.bricks.base import application
 from blocks.bricks.parallel import Distribute
 from blocks.bricks.recurrent import SimpleRecurrent, GatedRecurrent
-from blocks.bricks.attention import SequenceContentAttention
+from blocks.bricks.attention import (
+    SequenceContentAttention, AttentionRecurrent)
 from blocks.bricks.sequence_generators import (
     SequenceGenerator, LinearReadout, TrivialEmitter,
-    SoftmaxEmitter, LookupFeedback, AttentionTransition)
+    SoftmaxEmitter, LookupFeedback)
 from blocks.graph import ComputationGraph
 from blocks.initialization import Orthogonal, IsotropicGaussian, Constant
 
@@ -142,8 +143,8 @@ def test_attention_transition():
     distribute = Distribute([name for name in transition.apply.sequences
                              if name != 'mask'],
                             attention.take_look.outputs[0])
-    att_trans = AttentionTransition(transition, attention, distribute,
-                                    name="att_trans")
+    att_trans = AttentionRecurrent(transition, attention, distribute,
+                                   name="att_trans")
     att_trans.weights_init = IsotropicGaussian(0.01)
     att_trans.biases_init = Constant(0)
     att_trans.initialize()

--- a/tests/bricks/test_sequence_generators.py
+++ b/tests/bricks/test_sequence_generators.py
@@ -5,7 +5,6 @@ from theano import tensor
 
 from blocks.bricks import Tanh
 from blocks.bricks.base import application
-from blocks.bricks.parallel import Distribute
 from blocks.bricks.recurrent import SimpleRecurrent, GatedRecurrent
 from blocks.bricks.attention import (
     SequenceContentAttention, AttentionRecurrent)

--- a/tests/bricks/test_sequence_generators.py
+++ b/tests/bricks/test_sequence_generators.py
@@ -128,7 +128,7 @@ class TestTransition(SimpleRecurrent):
         return super(TestTransition, self).get_dim(name)
 
 
-def test_attention_transition():
+def test_with_attention():
     inp_dim = 2
     inp_len = 10
     attended_dim = 3
@@ -136,15 +136,11 @@ def test_attention_transition():
     batch_size = 4
     n_steps = 30
 
-    transition = TestTransition(dim=inp_dim, attended_dim=attended_dim,
-                                name="transition")
-    attention = SequenceContentAttention(transition.apply.states,
-                                         match_dim=inp_dim, name="attention")
-    distribute = Distribute([name for name in transition.apply.sequences
-                             if name != 'mask'],
-                            attention.take_look.outputs[0])
-    att_trans = AttentionRecurrent(transition, attention, distribute,
-                                   name="att_trans")
+    transition = TestTransition(dim=inp_dim, attended_dim=attended_dim)
+    attention = SequenceContentAttention(
+        transition.apply.states, match_dim=inp_dim, name="attention")
+    att_trans = AttentionRecurrent(
+        transition, attention, add_contexts=False)
     att_trans.weights_init = IsotropicGaussian(0.01)
     att_trans.biases_init = Constant(0)
     att_trans.initialize()
@@ -187,7 +183,7 @@ def test_attention_transition():
         transition=transition,
         attention=attention,
         weights_init=IsotropicGaussian(0.01), biases_init=Constant(0),
-        name="generator")
+        add_contexts=False, name="generator")
 
     outputs = tensor.tensor3('outputs')
     costs = generator.cost(outputs, attended=attended,


### PR DESCRIPTION
Addresses #200.

This PR separates the `AttentionRecurrent` (former `AttentionTransition`) from the sequence generation framework and documents it. It is also made much more usable: now it does not require the wrapped transition to always have the attended context, now it also creates a basic version of `Distribute` automatically. 

In addition I introduce and document the common interface for attention bricks.

Altogether this should much easier to understand and read then the previous version of the code. @pbrakel , @dmitriy-serdyuk , can you as potential users of this give me some feedback?

By the way, the new `AttentionRecurrent` would make a great building block for hierarchical attention: a few of such bricks should be just chained.

For some reason the output values in the `test_attention_recurrent` test are non-deterministic and tests are either failing or not depending on how many of them I run. I am trying to figure out why.