### PR TITLE
Basic Scan Support in Computation Graph

### DIFF
--- a/blocks/graph.py
+++ b/blocks/graph.py
@@ -53,7 +53,7 @@ class ComputationGraph(object):
     scans : list of :class:`~theano.scan_module.scan_op.Scan`
         All Scan ops used in this computation graph.
     scan_variables : list of :class:`~tensor.TensorVariable`
-        All variables of inner graphs of Scan op.
+        All variables of the inner graphs of Scan ops.
     updates : :class:`~tensor.TensorSharedVariable` updates
         All the updates found attached to the annotations.
 

--- a/blocks/graph.py
+++ b/blocks/graph.py
@@ -7,6 +7,8 @@ import theano
 from theano import Variable
 from theano.gof import graph
 from theano.sandbox.rng_mrg import MRG_RandomStreams
+from theano.scan_module.scan_op import Scan
+from toolz import unique
 
 from blocks import config
 from blocks.roles import add_role, AUXILIARY
@@ -48,6 +50,10 @@ class ComputationGraph(object):
         Any variable that is not part of :attr:`inputs` or :attr:`outputs`.
     variables : list of :class:`~tensor.TensorVariable`
         All variables (including auxiliary) in the managed graph.
+    scans : list of :class:`~theano.scan_module.scan_op.Scan`
+        All Scan ops used in this computation graph.
+    scan_variables : list of :class:`~tensor.TensorVariable`
+        All variables of inner graphs of Scan op.
     updates : :class:`~tensor.TensorSharedVariable` updates
         All the updates found attached to the annotations.
 
@@ -82,8 +88,18 @@ class ComputationGraph(object):
         return [var for var in self.variables if hasattr(var.tag, 'roles') and
                 AUXILIARY in var.tag.roles]
 
+    @property
+    def scan_variables(self):
+        """Variables of Scan ops."""
+        return chain(*[g.variables for g in self._scan_graphs])
+
     def _get_variables(self):
-        """Collect variables, updates and auxiliary variables."""
+        """Collect variables, updates and auxiliary variables.
+
+        In addition collects all :class:`.Scan` ops and recurses in the
+        respective inner Theano graphs.
+
+        """
         updates = OrderedDict()
 
         shared_outputs = [o for o in self.outputs if is_shared_variable(o)]
@@ -95,6 +111,10 @@ class ComputationGraph(object):
             # duplicates
             inputs = graph.inputs(self.outputs)
             sorted_apply_nodes = graph.io_toposort(inputs, usual_outputs)
+            self.scans = list(unique([node.op for node in sorted_apply_nodes
+                                     if isinstance(node.op, Scan)]))
+            self._scan_graphs = [ComputationGraph(scan.outputs)
+                                 for scan in self.scans]
 
             seen = set()
             main_vars = [var for var in list(chain(

--- a/blocks/graph.py
+++ b/blocks/graph.py
@@ -91,7 +91,7 @@ class ComputationGraph(object):
     @property
     def scan_variables(self):
         """Variables of Scan ops."""
-        return chain(*[g.variables for g in self._scan_graphs])
+        return list(chain(*[g.variables for g in self._scan_graphs]))
 
     def _get_variables(self):
         """Collect variables, updates and auxiliary variables.

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -146,7 +146,8 @@ class Model(AbstractModel, ComputationGraph):
         if len(self.outputs) > 1:
             logger.warning("model with multiple output " + multiple_message)
 
-        bricks = [get_brick(var) for var in self if get_brick(var)]
+        bricks = [get_brick(var) for var
+                  in self.variables + self.scan_variables if get_brick(var)]
         children = set(chain(*(brick.children for brick in bricks)))
         # Quadratic complexity: we should not have thousands of
         # top-level bricks.

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -60,6 +60,15 @@ def test_computation_graph():
     assert W in cg5.variables
     assert w1 in cg5.variables
 
+    # Test scan
+    s, _ = theano.scan(lambda inp, accum: accum + inp,
+                       sequences=x,
+                       outputs_info=tensor.zeros_like(x[0]))
+    scan = s.owner.inputs[0].owner.op
+    cg6 = ComputationGraph(s)
+    assert cg6.scans == [scan]
+    assert all(v in cg6.scan_variables for v in scan.inputs + scan.outputs)
+
 
 def test_apply_noise():
     x = tensor.scalar()


### PR DESCRIPTION
This PR equips the `ComputationGraph` with two properties: `scans` and `scan_variables`. I did not provide access to the nested inner scan graphs so far: I hesitate what the right interface should be. 

The first consumer of this new feature is the `Model`.

