### PR TITLE
Save the original inner scan graph

### DIFF
--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -183,9 +183,8 @@ def recurrent(*args, **kwargs):
                 # We want to save the computation graph returned by the
                 # `application_function` when it is called inside the
                 # `theano.scan`.
-                application_call.inner_inputs = kwargs
-                application_call.inner_outputs = OrderedDict(
-                    zip(application.outputs, pack(outputs)))
+                application_call.inner_inputs = args
+                application_call.inner_outputs = outputs
                 return outputs
             outputs_info = (list(states_given.values()) +
                             [None] * (len(application.outputs) -

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -184,7 +184,7 @@ def recurrent(*args, **kwargs):
                 # `application_function` when it is called inside the
                 # `theano.scan`.
                 application_call.inner_inputs = args
-                application_call.inner_outputs = outputs
+                application_call.inner_outputs = pack(outputs)
                 return outputs
             outputs_info = (list(states_given.values()) +
                             [None] * (len(application.outputs) -

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -176,7 +176,7 @@ def recurrent(*args, **kwargs):
                 args = list(args)
                 arg_names = (list(sequences_given) + list(states_given) +
                              list(contexts_given))
-                kwargs = OrderedDict(zip(arg_names, args))
+                kwargs = dict(zip(arg_names, args))
                 kwargs.update(rest_kwargs)
                 outputs = getattr(brick, application_function.__name__)(
                     iterate=False, **kwargs)

--- a/tests/bricks/test_recurrent.py
+++ b/tests/bricks/test_recurrent.py
@@ -245,8 +245,8 @@ def test_saved_inner_graph():
     y = recurrent.apply(x)
 
     application_call = get_application_call(y)
-    assert list(application_call.inner_inputs) == ["inputs", "states"]
-    assert list(application_call.inner_outputs) == ["states"]
+    assert application_call.inner_inputs
+    assert application_call.inner_outputs
     # TODO before merge: test equivalence of the saved CG
     # and the one obtained by an explicit `iterate=False` call.
     # Need to consult Theano gurus for that.


### PR DESCRIPTION
While thinking about the best way to implement beam search for the sequence generator I realized that there should be a way to access the original inner graphs built by brick application methods before they were arbitrarily modified by `theano.scan` internals. That turned out to be a matter of two lines. I kind of dislike that the input and output variables of the graph saved like I do it here are not properly annotated.

@dmitriy-serdyuk , that should be all you need to build none computation graphs in the beam search and only use one provided by the user.