### PR TITLE
before_training as string

### DIFF
--- a/blocks/extensions/monitoring.py
+++ b/blocks/extensions/monitoring.py
@@ -124,7 +124,7 @@ class TrainingDataMonitoring(SimpleExtension, MonitoringExtension):
         aggregated values of the monitored variables to the log.
 
         """
-        if callback_name == self.before_training.__name__:
+        if callback_name == 'before_training':
             if not isinstance(self.main_loop.algorithm,
                               DifferentiableCostMinimizer):
                 raise ValueError


### PR DESCRIPTION
@rizar Came across this when reading the code. The name of a function is always `'before_training'` (if not, `self.before_training` would return an `AttributeError`) so not sure why it was done like this.