### PR TITLE
Orthogonal initialization for non-squared matrices. 

### DIFF
--- a/blocks/initialization.py
+++ b/blocks/initialization.py
@@ -156,16 +156,26 @@ class Identity(NdarrayInitialization):
 class Orthogonal(NdarrayInitialization):
     """Initialize a random orthogonal matrix.
 
-    Only works for 2D, square arrays.
+    Only works for 2D arrays.
 
     """
     def generate(self, rng, shape):
-        M = rng.randn(*shape).astype(theano.config.floatX)
+        if len(shape) != 2:
+            raise ValueError
+        M1 = rng.randn(shape[0], shape[0]).astype(theano.config.floatX)
+        M2 = rng.randn(shape[1], shape[1]).astype(theano.config.floatX)
+
         # QR decomposition of matrix with entries in N(0, 1) is random
-        Q, R = numpy.linalg.qr(M)
+        Q1, R1 = numpy.linalg.qr(M1)
+        Q2, R2 = numpy.linalg.qr(M2)
         # Correct that NumPy doesn't force diagonal of R to be non-negative
-        Q = Q * numpy.sign(numpy.diag(R))
-        return Q
+        Q1 = Q1 * numpy.sign(numpy.diag(R1))
+        Q2 = Q2 * numpy.sign(numpy.diag(R2))
+
+        n_min = min(shape[0], shape[1])
+        
+        W = numpy.dot(Q1[:, :n_min], Q2[:n_min, :])
+        return W
 
 
 class Sparse(NdarrayInitialization):

--- a/blocks/initialization.py
+++ b/blocks/initialization.py
@@ -173,9 +173,7 @@ class Orthogonal(NdarrayInitialization):
         Q2 = Q2 * numpy.sign(numpy.diag(R2))
 
         n_min = min(shape[0], shape[1])
-        
-        W = numpy.dot(Q1[:, :n_min], Q2[:n_min, :])
-        return W
+        return numpy.dot(Q1[:, :n_min], Q2[:n_min, :])
 
 
 class Sparse(NdarrayInitialization):

--- a/blocks/initialization.py
+++ b/blocks/initialization.py
@@ -162,6 +162,15 @@ class Orthogonal(NdarrayInitialization):
     def generate(self, rng, shape):
         if len(shape) != 2:
             raise ValueError
+
+        if shape[0] == shape[1]:
+            # For square weight matrices we can simplify the logic
+            # and be more exact:
+            M = rng.randn(*shape).astype(theano.config.floatX)
+            Q, R = numpy.linalg.qr(M)
+            Q = Q * numpy.sign(numpy.diag(R))
+            return Q
+
         M1 = rng.randn(shape[0], shape[0]).astype(theano.config.floatX)
         M2 = rng.randn(shape[1], shape[1]).astype(theano.config.floatX)
 

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -101,22 +101,21 @@ def test_orthogonal():
         WTW = numpy.dot(W.T, W)
 
         atol = 0.2
-        rtol = 0.1
 
         # Sanity check, just to be save
         assert WWT.shape == (shape[0], shape[0])
         assert WTW.shape == (shape[1], shape[1])
 
         # Diagonals ~= 1. ?
-        assert_allclose(numpy.diag(WWT), 1., atol=atol, rtol=rtol)
-        assert_allclose(numpy.diag(WTW), 1., atol=atol, rtol=rtol)
+        assert_allclose(numpy.diag(WWT), 1., atol=atol)
+        assert_allclose(numpy.diag(WTW), 1., atol=atol)
 
         # Non-diagonal ~= 0. ?
         WWT_residum = WWT-numpy.eye(shape[0])
         WTW_residum = WTW-numpy.eye(shape[1])
 
-        assert_allclose(WWT_residum, 0., atol=atol, rtol=rtol)
-        assert_allclose(WTW_residum, 0., atol=atol, rtol=rtol)
+        assert_allclose(WWT_residum, 0., atol=atol)
+        assert_allclose(WTW_residum, 0., atol=atol)
 
     yield check_orthogonal, rng, (50, 50)
     yield check_orthogonal, rng, (50, 51)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -3,7 +3,8 @@ import six
 import theano
 from numpy.testing import assert_equal, assert_allclose, assert_raises
 
-from blocks.initialization import Constant, IsotropicGaussian, Sparse, Uniform, Orthogonal
+from blocks.initialization import Constant, IsotropicGaussian, Sparse
+from blocks.initialization import Uniform, Orthogonal
 
 
 def test_constant():
@@ -84,6 +85,7 @@ def test_sparse():
     yield check_sparse, rng, 0.3, Constant(1.), None, (10, 10), 30
     yield check_sparse, rng, 0.3, Constant(0.), Constant(1.), (10, 10), 70
 
+
 def test_orthogonal():
     rng = numpy.random.RandomState(1)
 
@@ -91,13 +93,13 @@ def test_orthogonal():
         W = Orthogonal().generate(rng, shape)
 
         assert W.shape == shape
-        
-        # For square matrices the following to should 
+
+        # For square matrices the following to should
         # be diagonal. For non-square matrices, we relax
         # a bit.
         WWT = numpy.dot(W, W.T)
         WTW = numpy.dot(W.T, W)
-        
+
         atol = 0.2
         rtol = 0.1
 
@@ -105,11 +107,11 @@ def test_orthogonal():
         assert WWT.shape == (shape[0], shape[0])
         assert WTW.shape == (shape[1], shape[1])
 
-        # Diagonals == 1. ?
+        # Diagonals ~= 1. ?
         assert_allclose(numpy.diag(WWT), 1., atol=atol, rtol=rtol)
         assert_allclose(numpy.diag(WTW), 1., atol=atol, rtol=rtol)
 
-        # Non-diagonal 
+        # Non-diagonal ~= 0. ?
         WWT_residum = WWT-numpy.eye(shape[0])
         WTW_residum = WTW-numpy.eye(shape[1])
 
@@ -119,4 +121,3 @@ def test_orthogonal():
     yield check_orthogonal, rng, (50, 50)
     yield check_orthogonal, rng, (50, 51)
     yield check_orthogonal, rng, (51, 50)
-

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -3,7 +3,7 @@ import six
 import theano
 from numpy.testing import assert_equal, assert_allclose, assert_raises
 
-from blocks.initialization import Constant, IsotropicGaussian, Sparse, Uniform
+from blocks.initialization import Constant, IsotropicGaussian, Sparse, Uniform, Orthogonal
 
 
 def test_constant():
@@ -83,3 +83,40 @@ def test_sparse():
     yield check_sparse, rng, 3, Constant(0.), Constant(1.), (10, 10), 70
     yield check_sparse, rng, 0.3, Constant(1.), None, (10, 10), 30
     yield check_sparse, rng, 0.3, Constant(0.), Constant(1.), (10, 10), 70
+
+def test_orthogonal():
+    rng = numpy.random.RandomState(1)
+
+    def check_orthogonal(rng, shape):
+        W = Orthogonal().generate(rng, shape)
+
+        assert W.shape == shape
+        
+        # For square matrices the following to should 
+        # be diagonal. For non-square matrices, we relax
+        # a bit.
+        WWT = numpy.dot(W, W.T)
+        WTW = numpy.dot(W.T, W)
+        
+        atol = 0.2
+        rtol = 0.1
+
+        # Sanity check, just to be save
+        assert WWT.shape == (shape[0], shape[0])
+        assert WTW.shape == (shape[1], shape[1])
+
+        # Diagonals == 1. ?
+        assert_allclose(numpy.diag(WWT), 1., atol=atol, rtol=rtol)
+        assert_allclose(numpy.diag(WTW), 1., atol=atol, rtol=rtol)
+
+        # Non-diagonal 
+        WWT_residum = WWT-numpy.eye(shape[0])
+        WTW_residum = WTW-numpy.eye(shape[1])
+
+        assert_allclose(WWT_residum, 0., atol=atol, rtol=rtol)
+        assert_allclose(WTW_residum, 0., atol=atol, rtol=rtol)
+
+    yield check_orthogonal, rng, (50, 50)
+    yield check_orthogonal, rng, (50, 51)
+    yield check_orthogonal, rng, (51, 50)
+


### PR DESCRIPTION
Before this patch Orthogonal initialization would only work for square matrices. 

In fact, it would silently(!) set shared weight variables to be square even though their shape was set to some other aspect ratio. As such I think the old behavior was even erroneous.
