### PR TITLE
Added references for shared parameters of learning algorithms

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -376,7 +376,7 @@ class Momentum(CompositeRule):
     momentum : :class:`~tensor.SharedVariable`
         A variable for momentum.
 
-    See also
+    See Also
     --------
     :class:`SharedVariableModifier` for a parameter decay during the
     training.
@@ -512,7 +512,7 @@ class RMSProp(CompositeRule):
     decay_rate : :class:`~tensor.SharedVariable`
         A variable for decay rate.
 
-    See also
+    See Also
     --------
     :class:`SharedVariableModifier` for a parameter decay during the
     training.

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -371,8 +371,12 @@ class Momentum(CompositeRule):
 
     """
     def __init__(self, learning_rate=1.0, momentum=0.):
-        self.components = [Scale(learning_rate=learning_rate),
-                           BasicMomentum(momentum=momentum)]
+        scale = Scale(learning_rate=learning_rate)
+        momentum_alg = BasicMomentum(momentum=momentum)
+        self.learning_rate = scale.learning_rate
+        self.momentum = momentum_alg.momentum
+        self.components = [scale,
+                           momentum_alg]
 
 
 class AdaDelta(StepRule):
@@ -492,9 +496,12 @@ class RMSProp(CompositeRule):
 
     """
     def __init__(self, learning_rate=1.0, decay_rate=0.9, max_scaling=1e5):
-        self.components = [
-            BasicRMSProp(decay_rate=decay_rate, max_scaling=max_scaling),
-            Scale(learning_rate=learning_rate)]
+        basic_rms_prop = BasicRMSProp(decay_rate=decay_rate,
+                                      max_scaling=max_scaling)
+        scale = Scale(learning_rate=learning_rate)
+        self.learning_rate = scale.learning_rate
+        self.decay_rate = basic_rms_prop.decay_rate
+        self.components = [basic_rms_prop, scale]
 
 
 class StepClipping(StepRule):

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -384,10 +384,10 @@ class Momentum(CompositeRule):
     """
     def __init__(self, learning_rate=1.0, momentum=0.):
         scale = Scale(learning_rate=learning_rate)
-        momentum_alg = BasicMomentum(momentum=momentum)
+        basic_momentum = BasicMomentum(momentum=momentum)
         self.learning_rate = scale.learning_rate
-        self.momentum = momentum_alg.momentum
-        self.components = [scale, momentum_alg]
+        self.momentum = basic_momentum.momentum
+        self.components = [scale, basic_momentum]
 
 
 class AdaDelta(StepRule):

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -369,10 +369,16 @@ class Momentum(CompositeRule):
     momentum : float, optional
         The momentum coefficient. Defaults to 0.
 
-    Notes
-    -----
-    The class has two shared variables: `learning_rate` and `momentum`.
-    See :class:`SharedVariableModifier` for a parameter decay during the
+    Attributes
+    ----------
+    learning_rate : :class:`~tensor.SharedVariable`
+        A variable for learning rate.
+    momentum : :class:`~tensor.SharedVariable`
+        A variable for momentum.
+
+    See also
+    --------
+    :class:`SharedVariableModifier` for a parameter decay during the
     training.
 
     """
@@ -499,10 +505,16 @@ class RMSProp(CompositeRule):
         Maximum scaling of the step size, in case the running average is
         really small. Defaults to 1e5.
 
-    Notes
-    -----
-    The class has two shared variables: `learning_rate` and `decay_rate`.
-    See :class:`SharedVariableModifier` for a parameter decay during the
+    Attributes
+    ----------
+    learning_rate : :class:`~tensor.SharedVariable`
+        A variable for learning rate.
+    decay_rate : :class:`~tensor.SharedVariable`
+        A variable for decay rate.
+
+    See also
+    --------
+    :class:`SharedVariableModifier` for a parameter decay during the
     training.
 
     """

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -369,14 +369,19 @@ class Momentum(CompositeRule):
     momentum : float, optional
         The momentum coefficient. Defaults to 0.
 
+    Notes
+    -----
+    The class has two shared variables: `learning_rate` and `momentum`.
+    See :class:`SharedVariableModifier` for a parameter decay during the
+    training.
+
     """
     def __init__(self, learning_rate=1.0, momentum=0.):
         scale = Scale(learning_rate=learning_rate)
         momentum_alg = BasicMomentum(momentum=momentum)
         self.learning_rate = scale.learning_rate
         self.momentum = momentum_alg.momentum
-        self.components = [scale,
-                           momentum_alg]
+        self.components = [scale, momentum_alg]
 
 
 class AdaDelta(StepRule):
@@ -493,6 +498,12 @@ class RMSProp(CompositeRule):
     max_scaling : float, optional
         Maximum scaling of the step size, in case the running average is
         really small. Defaults to 1e5.
+
+    Notes
+    -----
+    The class has two shared variables: `learning_rate` and `decay_rate`.
+    See :class:`SharedVariableModifier` for a parameter decay during the
+    training.
 
     """
     def __init__(self, learning_rate=1.0, decay_rate=0.9, max_scaling=1e5):


### PR DESCRIPTION
I added references to parameters of inner components of learning algorithms. It should help to use `SharedParameterModifier`, for example one should write
```python
SharedParameterModifier(momentum.momentum)
```
instead of
```python
SharedParameterModifier(momentum.components[0].momentum)
```