### PR TITLE
Fuel: ContainerDataset name change and no more get_default_stream

### DIFF
--- a/docs/plotting.rst
+++ b/docs/plotting.rst
@@ -41,9 +41,9 @@ We train on a 150 random points in :math:`[0, 1]`.
 
 >>> import numpy
 >>> from fuel.streams import DataStream
->>> from fuel.datasets import ContainerDataset
+>>> from fuel.datasets import IterableDataset
 >>> sample = theano.tensor.scalar('data')
->>> data_stream = DataStream(ContainerDataset(
+>>> data_stream = DataStream(IterableDataset(
 ...     numpy.random.rand(150).astype(theano.config.floatX)))
 
 Now let's train with gradient descent and plot the results.

--- a/doctests/test_doctest.py
+++ b/doctests/test_doctest.py
@@ -21,7 +21,6 @@ def setup(testobj):
 
 
 def load_tests(loader, tests, ignore):
-
     # This function loads doctests from all submodules and runs them
     # with the __future__ imports necessary for Python 2
     for _, module, _ in pkgutil.walk_packages(path=blocks.__path__,

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -137,7 +137,7 @@ def main(mode, save_path, num_batches, data_path=None):
                         data_stream=DataStreamFilter(
                             predicate=_filter_long,
                             data_stream=dataset
-                            .get_default_stream())))))
+                            .get_example_stream())))))
 
         # Build the cost computation graph
         chars = tensor.lmatrix("features")

--- a/examples/sqrt.py
+++ b/examples/sqrt.py
@@ -18,7 +18,7 @@ from blocks.bricks import MLP, Tanh, Identity
 from blocks.bricks.cost import SquaredError
 from blocks.initialization import IsotropicGaussian, Constant
 from blocks.model import Model
-from fuel.datasets import ContainerDataset
+from fuel.datasets import IterableDataset
 from fuel.streams import BatchDataStream, DataStreamMapping
 from fuel.schemes import ConstantScheme
 from blocks.extensions import FinishAfter, Timing, Printing
@@ -39,8 +39,8 @@ def _array_tuple(data):
 
 
 def get_data_stream(iterable):
-    dataset = ContainerDataset({'numbers': iterable})
-    data_stream = DataStreamMapping(dataset.get_default_stream(),
+    dataset = IterableDataset({'numbers': iterable})
+    data_stream = DataStreamMapping(dataset.get_example_stream(),
                                     _data_sqrt, add_sources=('roots',))
     data_stream = DataStreamMapping(data_stream, _array_tuple)
     return BatchDataStream(data_stream, ConstantScheme(20))

--- a/tests/extensions/test_monitoring.py
+++ b/tests/extensions/test_monitoring.py
@@ -1,6 +1,6 @@
 import numpy
 import theano
-from fuel.datasets import ContainerDataset
+from fuel.datasets import IterableDataset
 from numpy.testing import assert_allclose
 from theano import tensor
 
@@ -20,7 +20,7 @@ def test_training_data_monitoring():
                 for f in [[1, 2], [3, 4], [5, 6]]]
     targets = [(weights * f).sum() for f in features]
     n_batches = 3
-    dataset = ContainerDataset(dict(features=features, targets=targets))
+    dataset = IterableDataset(dict(features=features, targets=targets))
 
     x = tensor.vector('features')
     y = tensor.scalar('targets')
@@ -38,7 +38,7 @@ def test_training_data_monitoring():
                  data["targets"]) ** 2)
 
     main_loop = MainLoop(
-        model=None, data_stream=dataset.get_default_stream(),
+        model=None, data_stream=dataset.get_example_stream(),
         algorithm=GradientDescent(cost=cost, params=[W],
                                   step_rule=Scale(0.001)),
         extensions=[

--- a/tests/extensions/test_progressbar.py
+++ b/tests/extensions/test_progressbar.py
@@ -1,6 +1,6 @@
 import numpy
 import theano
-from fuel.datasets import ContainerDataset
+from fuel.datasets import IterableDataset
 from theano import tensor
 
 from blocks.algorithms import GradientDescent, Scale
@@ -20,7 +20,7 @@ def setup_mainloop(extension):
     """
     features = [numpy.array(f, dtype=floatX)
                 for f in [[1, 2], [3, 4], [5, 6]]]
-    dataset = ContainerDataset(dict(features=features))
+    dataset = IterableDataset(dict(features=features))
 
     W = shared_floatx([0, 0], name='W')
     x = tensor.vector('features')
@@ -31,7 +31,7 @@ def setup_mainloop(extension):
                                 step_rule=Scale(1e-3))
 
     main_loop = MainLoop(
-        model=None, data_stream=dataset.get_default_stream(),
+        model=None, data_stream=dataset.get_example_stream(),
         algorithm=algorithm,
         extensions=[
             FinishAfter(after_n_epochs=1),

--- a/tests/extensions/test_training.py
+++ b/tests/extensions/test_training.py
@@ -2,7 +2,7 @@ import numpy
 from numpy.testing import assert_allclose
 
 import theano
-from fuel.datasets import ContainerDataset
+from fuel.datasets import IterableDataset
 from theano import tensor
 
 from blocks.algorithms import GradientDescent, Scale
@@ -20,7 +20,7 @@ def test_shared_variable_modifier():
                 for f in [[1, 2], [3, 4], [5, 6]]]
     targets = [(weights * f).sum() for f in features]
     n_batches = 3
-    dataset = ContainerDataset(dict(features=features, targets=targets))
+    dataset = IterableDataset(dict(features=features, targets=targets))
 
     x = tensor.vector('features')
     y = tensor.scalar('targets')
@@ -32,7 +32,7 @@ def test_shared_variable_modifier():
     sgd = GradientDescent(cost=cost, params=[W],
                           step_rule=step_rule)
     main_loop = MainLoop(
-        model=None, data_stream=dataset.get_default_stream(),
+        model=None, data_stream=dataset.get_example_stream(),
         algorithm=sgd,
         extensions=[
             FinishAfter(after_n_epochs=1),
@@ -52,7 +52,7 @@ def test_shared_variable_modifier_two_params():
                 for f in [[1, 2], [3, 4], [5, 6]]]
     targets = [(weights * f).sum() for f in features]
     n_batches = 3
-    dataset = ContainerDataset(dict(features=features, targets=targets))
+    dataset = IterableDataset(dict(features=features, targets=targets))
 
     x = tensor.vector('features')
     y = tensor.scalar('targets')
@@ -67,7 +67,7 @@ def test_shared_variable_modifier_two_params():
         step_rule.learning_rate,
         lambda _, val: numpy.cast[floatX](val * 0.2))
     main_loop = MainLoop(
-        model=None, data_stream=dataset.get_default_stream(),
+        model=None, data_stream=dataset.get_example_stream(),
         algorithm=sgd,
         extensions=[FinishAfter(after_n_epochs=1), modifier])
 

--- a/tests/monitoring/test_evaluators.py
+++ b/tests/monitoring/test_evaluators.py
@@ -1,6 +1,6 @@
 import numpy
 import theano
-from fuel.datasets import ContainerDataset
+from fuel.datasets import IterableDataset
 from numpy.testing import assert_raises
 
 from blocks.graph import ComputationGraph
@@ -20,7 +20,7 @@ def test_dataset_evaluators():
 
     data = [numpy.arange(1, 5, dtype=floatX).reshape(2, 2),
             numpy.arange(10, 16, dtype=floatX).reshape(3, 2)]
-    data_stream = ContainerDataset(dict(X=data)).get_default_stream()
+    data_stream = IterableDataset(dict(X=data)).get_example_stream()
 
     values = validator.evaluate(data_stream)
     assert values['test_brick_apply_V_squared'] == 4
@@ -31,6 +31,6 @@ def test_dataset_evaluators():
         values['test_brick_apply_mean_batch_element'], per_batch_mean)
 
     with assert_raises(Exception) as ar:
-        data_stream = ContainerDataset(dict(X2=data)).get_default_stream()
+        data_stream = IterableDataset(dict(X2=data)).get_example_stream()
         validator.evaluate(data_stream)
     assert "Not all data sources" in ar.exception.args[0]

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -1,4 +1,4 @@
-from fuel.datasets import ContainerDataset
+from fuel.datasets import IterableDataset
 from six.moves import cPickle
 
 from blocks.main_loop import MainLoop
@@ -65,7 +65,7 @@ def test_main_loop():
 
 def test_training_resumption():
     def do_test(with_serialization):
-        data_stream = ContainerDataset(range(10)).get_default_stream()
+        data_stream = IterableDataset(range(10)).get_example_stream()
         main_loop = MainLoop(
             MockAlgorithm(), data_stream,
             extensions=[WriteBatchExtension(),


### PR DESCRIPTION
Parallel PR to https://github.com/bartvm/fuel/pull/20, see list of full changes there.

Most important for Blocks: `ContainerDataset` is now `IterableDataset`, `get_default_stream` is now `get_example_stream` and no longer returns batches for some datasets (only examples).