### PR TITLE
Streamline parameter passing to algorithms

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -57,9 +57,8 @@ class DifferentiableCostMinimizer(TrainingAlgorithm):
     ----------
     cost : :class:`~tensor.TensorVariable`
         The objective to be minimized.
-    params : list of :class:`~tensor.TensorSharedVariable`, optional
-        The parameters to be tuned. If ``None``, all shared variables of
-        `cost` computation graph will be considered parameters.
+    params : list of :class:`~tensor.TensorSharedVariable`
+        The parameters to be tuned.
 
     Attributes
     ----------
@@ -88,10 +87,9 @@ class DifferentiableCostMinimizer(TrainingAlgorithm):
        currently.
 
     """
-    def __init__(self, cost, params=None):
+    def __init__(self, cost, params):
         self.cost = cost
-        self.params = (params if params
-                       else ComputationGraph(cost).shared_variables)
+        self.params = params
         self._cost_computation_graph = ComputationGraph(self.cost)
         self._updates = []
 

--- a/blocks/filter.py
+++ b/blocks/filter.py
@@ -2,6 +2,7 @@ from inspect import isclass
 import re
 
 from blocks.bricks.base import ApplicationCall, Brick
+from blocks.roles import has_roles
 
 
 def get_annotation(var, cls):
@@ -104,17 +105,8 @@ class VariableFilter(object):
         """
         if self.roles:
             filtered_variables = []
-            for var in variables:
-                var_roles = getattr(var.tag, 'roles', [])
-                if self.each_role:
-                    if all(any(isinstance(var_role, role.__class__) for
-                               var_role in var_roles) for role in self.roles):
-                        filtered_variables.append(var)
-                else:
-                    if any(any(isinstance(var_role, role.__class__) for
-                               var_role in var_roles) for role in self.roles):
-                        filtered_variables.append(var)
-            variables = filtered_variables
+            variables = [var for var in variables
+                         if has_roles(var, self.roles, self.each_role)]
         if self.bricks is not None:
             filtered_variables = []
             for var in variables:

--- a/blocks/graph.py
+++ b/blocks/graph.py
@@ -11,7 +11,7 @@ from theano.scan_module.scan_op import Scan
 from toolz import unique
 
 from blocks import config
-from blocks.roles import add_role, AUXILIARY
+from blocks.roles import add_role, has_roles, AUXILIARY, PARAMETER
 from blocks.utils import (is_graph_input, is_shared_variable, dict_union,
                           shared_like)
 
@@ -41,6 +41,8 @@ class ComputationGraph(object):
         variables and constants.
     shared_variables : list of :class:`~tensor.TensorSharedVariable`
         All the shared variables in the graph.
+    parameters : list of :class:`~tensor.TensorSharedVariable`
+        All the shared variables which have the :const:`.PARAMETER` role.
     outputs : list of :class:`~tensor.TensorVariable`
         The outputs of the computations graph (as passed to the
         constructor).
@@ -84,9 +86,13 @@ class ComputationGraph(object):
         return [var for var in self.variables if is_shared_variable(var)]
 
     @property
+    def parameters(self):
+        return [var for var in self.shared_variables
+                if has_roles(var, [PARAMETER])]
+
+    @property
     def auxiliary_variables(self):
-        return [var for var in self.variables if hasattr(var.tag, 'roles') and
-                AUXILIARY in var.tag.roles]
+        return [var for var in self.variables if has_roles(var, [AUXILIARY])]
 
     @property
     def scan_variables(self):

--- a/blocks/roles.py
+++ b/blocks/roles.py
@@ -39,6 +39,26 @@ def add_role(var, role):
     var.tag.roles = roles
 
 
+def has_roles(var, roles, match_all=False):
+    r"""Test if a variable has given roles taking subroles into account.
+
+    Parameters
+    ----------
+    var : :class:`~tensor.TensorVariable`
+        Variable being queried.
+    roles : an iterable of :class:`.VariableRole` instances.
+    match_all : bool, optional
+        If ``True``, checks if the variable has all given roles.
+        If ``False``, any of the roles is sufficient.
+        ``False`` by default.
+
+    """
+    var_roles = getattr(var.tag, 'roles', [])
+    matches = (any(isinstance(var_role, role.__class__) for
+                   var_role in var_roles) for role in roles)
+    return all(matches) if match_all else any(matches)
+
+
 class VariableRole(object):
     """Base class for all variable roles."""
     def __eq__(self, other):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,6 +57,7 @@ Quickstart
    >>> from blocks.algorithms import GradientDescent, Scale
    >>> from blocks.bricks import MLP, Tanh, Softmax
    >>> from blocks.bricks.cost import CategoricalCrossEntropy, MisclassificationRate
+   >>> from blocks.graph import ComputationGraph
    >>> from blocks.initialization import IsotropicGaussian, Constant
    >>> from fuel.streams import DataStream
    >>> from fuel.datasets import MNIST
@@ -95,7 +96,8 @@ And train!
 >>> main_loop = MainLoop(
 ...     model=mlp, data_stream=train_stream,
 ...     algorithm=GradientDescent(
-...         cost=cost, step_rule=Scale(learning_rate=0.1)),
+...         cost=cost, params=ComputationGraph(cost).parameters,
+...         step_rule=Scale(learning_rate=0.1)),
 ...     extensions=[FinishAfter(after_n_epochs=5),
 ...                 DataStreamMonitoring(
 ...                     variables=[cost, error_rate],

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -189,7 +189,8 @@ of size 256.
 As our algorithm we will use straightforward SGD with a fixed learning rate.
 
 >>> from blocks.algorithms import GradientDescent, Scale
->>> algorithm = GradientDescent(cost=cost, step_rule=Scale(learning_rate=0.1))
+>>> algorithm = GradientDescent(cost=cost, params=cg.parameters,
+...                             step_rule=Scale(learning_rate=0.1))
 
 During training we will want to monitor the performance of our model on
 a separate set of examples. Let's create a new data stream for that.

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -44,7 +44,8 @@ def main(save_to, num_epochs):
     mnist_test = MNIST("test")
 
     algorithm = GradientDescent(
-        cost=cost, step_rule=Scale(learning_rate=0.1))
+        cost=cost, params=cg.parameters,
+        step_rule=Scale(learning_rate=0.1))
     main_loop = MainLoop(
         algorithm,
         DataStream(mnist_train,

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -187,8 +187,8 @@ def main(mode, save_path, num_batches, data_path=None):
 
         # Define the training algorithm.
         algorithm = GradientDescent(
-            cost=cost, step_rule=CompositeRule([StepClipping(10.0),
-                                                Scale(0.01)]))
+            cost=cost, params=cg.parameters,
+            step_rule=CompositeRule([StepClipping(10.0), Scale(0.01)]))
 
         # More variables for debugging
         observables = [

--- a/examples/sqrt.py
+++ b/examples/sqrt.py
@@ -16,6 +16,7 @@ from theano import tensor
 from blocks.algorithms import GradientDescent, Scale
 from blocks.bricks import MLP, Tanh, Identity
 from blocks.bricks.cost import SquaredError
+from blocks.graph import ComputationGraph
 from blocks.initialization import IsotropicGaussian, Constant
 from blocks.model import Model
 from fuel.datasets import IterableDataset
@@ -58,7 +59,8 @@ def main(save_to, num_batches, continue_=False):
 
     main_loop = MainLoop(
         GradientDescent(
-            cost=cost, step_rule=Scale(learning_rate=0.001)),
+            cost=cost, params=ComputationGraph(cost).parameters,
+            step_rule=Scale(learning_rate=0.001)),
         get_data_stream(range(100)),
         model=Model(cost),
         extensions=([LoadFromDump(save_to)] if continue_ else []) +


### PR DESCRIPTION
DifferentiableCostMinimizer needs to know which parameters are being
optimized and currently it gets all shared variables from the graph.
This is bad because assumes that all shared variables are trainable
that is not true for constants such as ones in MRG_RandomStream.

Having user always specify parameters improves transparency and
keeps framework modular. For convenience, add new property to
ComputationGraph. To avoid circular dependencies, implement role lookup
in roles.py and make both VariableFilter and ComputationGraph use it.

Fixes #364