### PR TITLE
Fix ConvolutionalSequence 

### DIFF
--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -336,7 +336,7 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
         image_size = self.image_size
         for layer in self.layers:
             if isinstance(layer, MaxPooling):
-                layer.input_dim = image_size
+                layer.input_dim = (num_channels,) + image_size
             else:
             	layer.image_size = image_size
             	layer.num_channels = num_channels
@@ -350,7 +350,7 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
             if isinstance(layer, MaxPooling):
                 if layer.input_dim is not None:
                     output_shape = layer.get_dim('output')
-                    image_size = output_shape
+                    image_size = output_shape[1:]
             else:
                 if layer.image_size is not None:
                     output_shape = layer.get_dim('output')

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -336,7 +336,7 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
         image_size = self.image_size
         for layer in self.layers:
             if isinstance(layer, MaxPooling):
-		layer.input_dim = image_size
+                layer.input_dim = image_size
             else:
             	layer.image_size = image_size
             	layer.num_channels = num_channels
@@ -347,10 +347,15 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
 
             # Retrieve output dimensions
             # and set it for next layer
-            #if layer.image_size is not None:
-            output_shape = layer.get_dim('output')
-            image_size = output_shape[1:]
-            num_channels = output_shape[0]
+            if isinstance(layer, MaxPooling):
+                if layer.input_dim is not None:
+                    output_shape = layer.get_dim('output')
+                    image_size = output_shape
+            else:
+                if layer.image_size is not None:
+                    output_shape = layer.get_dim('output')
+                    image_size = output_shape[1:]
+                    num_channels = output_shape[0]  
 
 
 class Flattener(Brick):

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -338,8 +338,8 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
             if isinstance(layer, MaxPooling):
                 layer.input_dim = (num_channels,) + image_size
             else:
-            	layer.image_size = image_size
-            	layer.num_channels = num_channels
+                layer.image_size = image_size
+                layer.num_channels = num_channels
             layer.batch_size = self.batch_size
 
             # Push input dimensions to children
@@ -355,7 +355,7 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
                 if layer.image_size is not None:
                     output_shape = layer.get_dim('output')
                     image_size = output_shape[1:]
-                    num_channels = output_shape[0]  
+                    num_channels = output_shape[0]
 
 
 class Flattener(Brick):

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -335,8 +335,11 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
         num_channels = self.num_channels
         image_size = self.image_size
         for layer in self.layers:
-            layer.image_size = image_size
-            layer.num_channels = num_channels
+            if isinstance(layer, MaxPooling):
+		layer.input_dim = image_size
+            else:
+            	layer.image_size = image_size
+            	layer.num_channels = num_channels
             layer.batch_size = self.batch_size
 
             # Push input dimensions to children
@@ -344,10 +347,10 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
 
             # Retrieve output dimensions
             # and set it for next layer
-            if layer.image_size is not None:
-                output_shape = layer.get_dim('output')
-                image_size = output_shape[1:]
-            num_channels = layer.num_filters
+            #if layer.image_size is not None:
+            output_shape = layer.get_dim('output')
+            image_size = output_shape[1:]
+            num_channels = output_shape[0]
 
 
 class Flattener(Brick):

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -160,6 +160,8 @@ class MainLoop(object):
                 # of the main loop.
                 if self.log.status.iterations_done > 0:
                     self._run_extensions('on_resumption')
+                    self.status._epoch_interrupt_received = False
+                    self.status._batch_interrupt_received = False
                 while self._run_epoch():
                     pass
             except TrainingFinish:


### PR DESCRIPTION
The push_allocation_config didn't work if there was a separate MaxPooling in layers of ConvolutionalSequence. The problem is that MaxPooling doesn't have an image_size, but input_dim instead. For now, I just check if a layer is an instance of MaxPooling, but we might also consider renaming input_dim to image_size for cleaner code. 