### PR TITLE
Added support to remote bokeh-server

### DIFF
--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -59,9 +59,9 @@ class Plot(SimpleExtension):
         start the server manually using the ``bokeh-server`` command. Also
         see the warning above.
     server_url : str, optional
-        Url that the bokeh-server is listening to. Ex: when starting the
-        bokeh-server with ``bokeh-server --ip your.i.p.here``, server_url
-        should be ``http://your.i.p.here:5006``.
+        Url of the bokeh-server is listening to. Ex: when starting the
+        bokeh-server with ``bokeh-server --ip 0.0.0.0`` at ``alice``, server_url
+        should be ``http://alice:5006``.
 
     """
     # Tableau 10 colors

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -59,7 +59,7 @@ class Plot(SimpleExtension):
         start the server manually using the ``bokeh-server`` command. Also
         see the warning above.
     server_url : str, optional
-        Url of the bokeh-server is listening to. Ex: when starting the
+        Url of the bokeh-server. Ex: when starting the
         bokeh-server with ``bokeh-server --ip 0.0.0.0`` at ``alice``, server_url
         should be ``http://alice:5006``.
 

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -58,6 +58,10 @@ class Plot(SimpleExtension):
         it down you will lose your plots. If you want to store your plots,
         start the server manually using the ``bokeh-server`` command. Also
         see the warning above.
+    server_url : str, optional
+        Url that the bokeh-server is listening to. Ex: when starting the
+        bokeh-server with ``bokeh-server --ip your.i.p.here``, server_url
+        should be ``http://your.i.p.here:5006``.
 
     """
     # Tableau 10 colors
@@ -65,12 +69,13 @@ class Plot(SimpleExtension):
               '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf']
 
     def __init__(self, document, channels, open_browser=False,
-                 start_server=False, **kwargs):
+                 start_server=False, server_url='default', **kwargs):
         if not BOKEH_AVAILABLE:
             raise ImportError
         self.plots = {}
         self.start_server = start_server
         self.document = document
+        self.server_url = server_url
         self._startserver()
 
         # Create figures for each group of channels
@@ -123,7 +128,7 @@ class Plot(SimpleExtension):
             logger.info('Plotting server PID: {}'.format(self.sub.pid))
         else:
             self.sub = None
-        output_server(self.document)
+        output_server(self.document, url=self.server_url)
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -59,8 +59,8 @@ class Plot(SimpleExtension):
         start the server manually using the ``bokeh-server`` command. Also
         see the warning above.
     server_url : str, optional
-        Url of the bokeh-server. Ex: when starting the bokeh-server with 
-        ``bokeh-server --ip 0.0.0.0`` at ``alice``, server_url should be 
+        Url of the bokeh-server. Ex: when starting the bokeh-server with
+        ``bokeh-server --ip 0.0.0.0`` at ``alice``, server_url should be
         ``http://alice:5006``.
 
     """

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -59,9 +59,9 @@ class Plot(SimpleExtension):
         start the server manually using the ``bokeh-server`` command. Also
         see the warning above.
     server_url : str, optional
-        Url of the bokeh-server. Ex: when starting the
-        bokeh-server with ``bokeh-server --ip 0.0.0.0`` at ``alice``, server_url
-        should be ``http://alice:5006``.
+        Url of the bokeh-server. Ex: when starting the bokeh-server with 
+        ``bokeh-server --ip 0.0.0.0`` at ``alice``, server_url should be 
+        ``http://alice:5006``.
 
     """
     # Tableau 10 colors


### PR DESCRIPTION
If you started your bokeh-server using an --ip flag that is not the default, blocks won't feed its update and will crash. This PR adds support to any bokeh-server url. The default value keeps live plotting exactly as it was before. Thus, there is nothing to lose in here.