### PR TITLE
Added dummy cost to TrivialEmitter

### DIFF
--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -394,6 +394,10 @@ class TrivialEmitter(AbstractEmitter):
     readout_dim : int
         The dimension of the readout.
 
+    Notes
+    -----
+    By default :meth:`cost` always returns zero tensor.
+
     """
     @lazy
     def __init__(self, readout_dim, **kwargs):

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -405,6 +405,10 @@ class TrivialEmitter(AbstractEmitter):
         return readouts
 
     @application
+    def cost(self, readouts, outputs):
+        return tensor.zeros_like(outputs)
+
+    @application
     def initial_outputs(self, batch_size, *args, **kwargs):
         return tensor.zeros((batch_size, self.readout_dim))
 


### PR DESCRIPTION
`TrivialEmitter` shouldn't be abstract.