### PR TITLE
Increase default learning rate Adam from 0.0002 to 0.002

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -596,7 +596,7 @@ class Adam(StepRule):
         Default value is set to 1e-8.
 
     """
-    def __init__(self, learning_rate=0.0002,
+    def __init__(self, learning_rate=0.002,
                  beta1=0.1, beta2=0.001, epsilon=1e-8,
                  decay_factor=1e-8):
         self.learning_rate = learning_rate

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -162,9 +162,10 @@ def test_adam():
         OrderedDict([(a, tensor.grad(cost, a))]))
     f = theano.function([], [steps[a]], updates=updates)
 
-    assert_allclose(f()[0], [0.0002, 0.0002], rtol=1e-5)
-    assert_allclose(f()[0], [0.00105263, 0.00105263], rtol=1e-5)
-    assert_allclose(f()[0], [0.00073801, 0.00073801], rtol=1e-5)
+    rtol = 1e-4
+    assert_allclose(f()[0], [0.002, 0.002], rtol=rtol)
+    assert_allclose(f()[0], [0.01052621, 0.01052621], rtol=rtol)
+    assert_allclose(f()[0], [0.00738005, 0.00738005], rtol=rtol)
 
 
 def test_remove_not_finite():


### PR DESCRIPTION
As suggested by @dpkingma. @memimo, you committed the original version, any particular reason you chose 0.0002?