### PR TITLE
Add Merge brick and tests

### DIFF
--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -281,7 +281,30 @@ class Merge(Parallel):
     child_prefix : str, optional
         A prefix for children names. By default "transform" is used.
 
+    Attributes
+    ----------
+    input_names : list of str
+        The input names.
+    input_dims : dict
+        Dictionary of input dimensions.
+    output_dim : int
+        Dictionary of output dimensions.
+
+    Examples
+    --------
+    >>> from theano import tensor
+    >>> from blocks.initialization import Constant
+    >>> a = tensor.matrix('a')
+    >>> b = tensor.matrix('b')
+    >>> merge = Merge(input_names=['a', 'b'], input_dims={'a': 3, 'b': 4},
+    ...               output_dim=2, weights_init=Constant(1.))
+    >>> merge.initialize()
+    >>> c = merge.apply(a=a, b=b)
+    >>> c.eval({a: [[1, 1, 1]], b: [[2, 2, 2, 2]]})  # doctest: +ELLIPSIS
+    array([[ 11.,  11.]]...
+
     """
+    @lazy
     def __init__(self, input_names, input_dims, output_dim, **kwargs):
         super(Merge, self).__init__(
             input_names, input_dims,
@@ -291,3 +314,13 @@ class Merge(Parallel):
     def apply(self, *args, **kwargs):
         outputs = super(Merge, self).apply(*args, **kwargs)
         return tensor.sum(outputs, axis=0)
+
+    @property
+    def output_dim(self):
+        return self._output_dim
+
+    @output_dim.setter
+    def output_dim(self, value):
+        self._output_dim = value
+        self.output_dims = {input_name: value
+                            for input_name in self.input_names}

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -7,7 +7,7 @@ from theano import tensor
 from blocks.bricks import (Identity, Linear, Maxout, LinearMaxout, MLP, Tanh,
                            Sequence)
 from blocks.bricks.base import Application, application, Brick, lazy
-from blocks.bricks.parallel import Parallel, Fork, Merge
+from blocks.bricks.parallel import Parallel, Fork
 from blocks.filter import get_application_call, get_brick
 from blocks.initialization import Constant
 from blocks.utils import shared_floatx
@@ -469,22 +469,3 @@ def test_linear_nan_allocation():
     b2 = linear.params[1].get_value()
     numpy.testing.assert_equal(w1, w2)
     numpy.testing.assert_equal(b1, b2)
-
-
-def test_merge():
-    a = tensor.matrix('a')
-    b = tensor.matrix('b')
-    rng = numpy.random.RandomState(1)
-    a_val = rng.rand(3, 10).astype(theano.config.floatX)
-    b_val = rng.rand(3, 20).astype(theano.config.floatX)
-
-    merge = Merge(input_names=['a', 'b'], input_dims={'a': 10, 'b': 20},
-                  output_dim=5, weights_init=Constant(1.))
-    merge.initialize()
-    c = merge.apply(a=a, b=b)
-
-    c_val = c.eval({a: a_val, b: b_val})
-    assert c_val.shape == (3, 5)
-
-    assert_allclose(c_val[:, 0],
-                    numpy.sum(a_val, axis=1) + numpy.sum(b_val, axis=1))

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -7,7 +7,7 @@ from theano import tensor
 from blocks.bricks import (Identity, Linear, Maxout, LinearMaxout, MLP, Tanh,
                            Sequence)
 from blocks.bricks.base import Application, application, Brick, lazy
-from blocks.bricks.parallel import Parallel, Fork
+from blocks.bricks.parallel import Parallel, Fork, Merge
 from blocks.filter import get_application_call, get_brick
 from blocks.initialization import Constant
 from blocks.utils import shared_floatx
@@ -469,3 +469,22 @@ def test_linear_nan_allocation():
     b2 = linear.params[1].get_value()
     numpy.testing.assert_equal(w1, w2)
     numpy.testing.assert_equal(b1, b2)
+
+
+def test_merge():
+    a = tensor.matrix('a')
+    b = tensor.matrix('b')
+    rng = numpy.random.RandomState(1)
+    a_val = rng.rand(3, 10).astype(theano.config.floatX)
+    b_val = rng.rand(3, 20).astype(theano.config.floatX)
+
+    merge = Merge(input_names=['a', 'b'], input_dims={'a': 10, 'b': 20},
+                  output_dim=5, weights_init=Constant(1.))
+    merge.initialize()
+    c = merge.apply(a=a, b=b)
+
+    c_val = c.eval({a: a_val, b: b_val})
+    assert c_val.shape == (3, 5)
+
+    assert_allclose(c_val[:, 0],
+                    numpy.sum(a_val, axis=1) + numpy.sum(b_val, axis=1))


### PR DESCRIPTION
@rizar As discussed.

Working with the parallel bricks made me curious: Why all the dictionaries and keyword arguments? It seems really redundant to pass: `Parallel(['a', 'b'], {'a': 10, 'b': 20}, {'a': 5, 'b': 7})` instead of `Parallel(['a', 'b'], [10, 20], [5, 7])`. Is there any particular reason for doing it like this?