### PR TITLE
Interrupting and resuming training

### DIFF
--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -160,6 +160,8 @@ class MainLoop(object):
                 # of the main loop.
                 if self.log.status.iterations_done > 0:
                     self._run_extensions('on_resumption')
+                    self.status._epoch_interrupt_received = False
+                    self.status._batch_interrupt_received = False
                 while self._run_epoch():
                     pass
             except TrainingFinish:


### PR DESCRIPTION
As observed by @capybaralet and me, interrupting and resuming training doesn't work properly. After interrupting the current epoch, resuming training will do only one epoch. I think the problem is that ```_epoch_interrupt_received``` and ```_batch_interrupt_received``` are not reset whenever we resume training. 