### PR TITLE
Beam search output

### DIFF
--- a/blocks/search.py
+++ b/blocks/search.py
@@ -239,7 +239,7 @@ class BeamSearch(object):
         return numpy.unravel_index(args, matrix.shape), flatten[args]
 
     def search(self, input_values, eol_symbol, max_length,
-               ignore_first_eol=False, as_lists=False):
+               ignore_first_eol=False, as_arrays=False):
         """Performs beam search.
 
         If the beam search was not compiled, it also compiles it.
@@ -263,19 +263,19 @@ class BeamSearch(object):
             first iteration are ignored. This useful when the sequence
             generator was trained on data with identical symbols for
             sequence start and sequence end.
-        as_lists : bool, optional
-            If ``True``, a list of trimmed output sequences and a list of
-            their costs are returned, instead of the default output format.
+        as_arrays : bool, optional
+            If ``True``, the internal representation of search results
+            is returned, that is a (matrix of outputs, mask,
+            costs of all generated outputs) tuple.
 
         Returns
         -------
-        outputs : :class:`numpy.ndarray`
-            The generated sequences, time is the first axis, the number in
-            the beam is the second.
-        mask : :class:`numpy.ndarray`
-            The mask for the outputs, same layout as `outputs`
-        costs : :class:`numpy.ndarray`
-            Generation costs for outputs, same layout as `outputs`.
+        outputs : list of lists of ints
+            A list of the `beam_size` best sequences found in the order
+            of decreasing likelihood.
+        costs : list of floats
+            A list of the costs for the `outputs`, where cost is the
+            negative log-likelihood.
 
         """
         if not self.compiled:
@@ -328,9 +328,9 @@ class BeamSearch(object):
         all_masks = all_masks[:-1]
         all_costs = all_costs[1:] - all_costs[:-1]
         result = all_outputs, all_masks, all_costs
-        if as_lists:
-            return self.result_to_lists(result)
-        return result
+        if as_arrays:
+            return result
+        return self.result_to_lists(result)
 
     @staticmethod
     def result_to_lists(result):

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -283,24 +283,21 @@ def main(mode, save_path, num_batches, data_path=None):
                 # a new `BeamSearch` object every time if
                 # speed is important for you.
                 beam_search = BeamSearch(input_.shape[1], samples)
-                outputs, _, costs = beam_search.search(
+                outputs, costs = beam_search.search(
                     {chars: input_}, char2code['</S>'],
                     3 * input_.shape[0])
             else:
                 _1, outputs, _2, _3, costs = (
                     model.get_theano_function()(input_))
-                costs = costs.T
-
-            outputs = list(outputs.T)
-            costs = list(costs)
-            for i in range(len(outputs)):
-                outputs[i] = list(outputs[i])
-                try:
-                    true_length = outputs[i].index(char2code['</S>']) + 1
-                except ValueError:
-                    true_length = len(outputs[i])
-                outputs[i] = outputs[i][:true_length]
-                if mode == "sample":
+                outputs = list(outputs.T)
+                costs = list(costs.T)
+                for i in range(len(outputs)):
+                    outputs[i] = list(outputs[i])
+                    try:
+                        true_length = outputs[i].index(char2code['</S>']) + 1
+                    except ValueError:
+                        true_length = len(outputs[i])
+                    outputs[i] = outputs[i][:true_length]
                     costs[i] = costs[i][:true_length].sum()
             return outputs, costs
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -33,7 +33,7 @@ def test_beam_search():
     beam_size = 10
     length = 15
 
-    reverser = WordReverser(10, alphabet_size)
+    reverser = WordReverser(10, alphabet_size, seed=1234)
     reverser.weights_init = reverser.biases_init = IsotropicGaussian(0.5)
     reverser.initialize()
 
@@ -47,9 +47,10 @@ def test_beam_search():
     search = BeamSearch(10, samples)
     results, mask, costs = search.search({inputs: input_vals},
                                          0, 3 * length)
+    assert results.sum() == 1240
 
     true_costs = reverser.cost(
         input_vals, numpy.ones((length, beam_size), dtype=floatX),
         results, mask).eval()
     true_costs = (true_costs * mask).sum(axis=0)
-    assert_allclose(costs, true_costs, rtol=1e-5)
+    assert_allclose(costs.sum(axis=0), true_costs, rtol=1e-5)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -45,8 +45,8 @@ def test_beam_search():
                             (beam_size, 1)).T
 
     search = BeamSearch(10, samples)
-    results, mask, costs = search.search({inputs: input_vals},
-                                         0, 3 * length)
+    results, mask, costs = search.search(
+        {inputs: input_vals}, 0, 3 * length, as_arrays=True)
     assert results.sum() == 1240
 
     true_costs = reverser.cost(
@@ -57,6 +57,6 @@ def test_beam_search():
 
     # Test `as_lists=True`
     results2, costs2 = search.search({inputs: input_vals},
-                                     0, 3 * length, as_lists=True)
+                                     0, 3 * length)
     for i in range(len(results2)):
         results2[i] == list(results.T[i, :mask.T[i].sum()])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -54,3 +54,9 @@ def test_beam_search():
         results, mask).eval()
     true_costs = (true_costs * mask).sum(axis=0)
     assert_allclose(costs.sum(axis=0), true_costs, rtol=1e-5)
+
+    # Test `as_lists=True`
+    results2, costs2 = search.search({inputs: input_vals},
+                                     0, 3 * length, as_lists=True)
+    for i in range(len(results2)):
+        results2[i] == list(results.T[i, :mask.T[i].sum()])


### PR DESCRIPTION
A few improvements for beam search:

- now it can return costs of all generated symbols. This is helpful for debugging.

- now mask is accumulated in the same way as outputs, because after `ignore_first_eol` options was introduced the old way of computing mask became invalid

- added `as_lists` flag to return list of results instead of masked numpy arrays

@dmitriy-serdyuk , will you take a look?