### PR TITLE
Yet Another Attention Refactoring

### DIFF
--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -32,8 +32,8 @@ in this file:
 Using this terminology, the attention mechanism computes glimpses
 given the states of the network and the attended.
 
-An example: in the machine translation network from [BCB]_ the attended is a
-sequence of so-called annotations, that is states of a bidirectional
+An example: in the machine translation network from [BCB]_ the attended is
+a sequence of so-called annotations, that is states of a bidirectional
 network that was driven by word embeddings of the source sentence. The
 attention mechanism assigns weights to the annotations. The weighted sum of
 the annotations is further used by the translation network to predict the

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -375,7 +375,7 @@ class SequenceContentAttention(GenericSequenceAttention, Initializable):
                                          states)
         weights = self.compute_weights(energies, attended_mask)
         weighted_averages = self.compute_weighted_averages(weights, attended)
-        return weighted_averages, weights.dimshuffle(1, 0)
+        return weighted_averages, weights.T
 
     @take_glimpses.property('inputs')
     def take_glimpses_inputs(self):

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -32,7 +32,7 @@ in this file:
 Using this terminology, the attention mechanism computes glimpses
 given the states of the network and the attended.
 
-An example: in the machine translation network from [BCB] the attended is a
+An example: in the machine translation network from [BCB]_ the attended is a
 sequence of so-called annotations, that is states of a bidirectional
 network that was driven by word embeddings of the source sentence. The
 attention mechanism assigns weights to the annotations. The weighted sum of
@@ -100,7 +100,9 @@ class AbstractAttention(Brick):
 
     Attributes
     ----------
-    Same as parameteres.
+    state_names : list of str
+    state_dims : dict
+    attended_dim : int
 
     """
     @lazy

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -360,7 +360,7 @@ class SequenceContentAttention(GenericSequenceAttention, Initializable):
         attended_mask : :class:`~tensor.TensorVariable`
             A 0/1 mask specifying available data. 0 means that the
             corresponding sequence element is fake.
-        *\*states
+        **states
             The states of the network.
 
         Returns

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -199,7 +199,6 @@ class AbstractAttention(Brick):
 
 class GenericSequenceAttention(AbstractAttention):
     """Logic common for sequence attention mechanisms."""
-
     @application
     def compute_weights(self, energies, attended_mask):
         """Compute weights from energies in softmax-like fashion.

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -105,7 +105,7 @@ class WordReverser(Initializable):
             dim=dimension, name="transition")
         attention = SequenceContentAttention(
             state_names=transition.apply.states,
-            sequence_dim=2 * dimension, match_dim=dimension, name="attention")
+            attended_dim=2 * dimension, match_dim=dimension, name="attention")
         readout = LinearReadout(
             readout_dim=alphabet_size, source_names=["states"],
             emitter=SoftmaxEmitter(name="emitter"),

--- a/tests/bricks/test_attention.py
+++ b/tests/bricks/test_attention.py
@@ -22,12 +22,12 @@ def test_sequence_content_attention():
     seq_len = 5
     batch_size = 6
     state_dim = 2
-    sequence_dim = 3
+    attended_dim = 3
     match_dim = 4
 
     attention = SequenceContentAttention(
         state_names=["states"], state_dims={"states": state_dim},
-        sequence_dim=sequence_dim, match_dim=match_dim,
+        attended_dim=attended_dim, match_dim=match_dim,
         weights_init=IsotropicGaussian(0.5),
         biases_init=Constant(0))
     attention.initialize()
@@ -35,12 +35,12 @@ def test_sequence_content_attention():
     sequences = tensor.tensor3('sequences')
     states = tensor.matrix('states')
     mask = tensor.matrix('mask')
-    glimpses, weights = attention.take_glimpses(sequences, states=states,
-                                                mask=mask)
+    glimpses, weights = attention.take_glimpses(
+        sequences, attended_mask=mask, states=states)
     assert glimpses.ndim == 2
     assert weights.ndim == 2
 
-    seq_values = numpy.zeros((seq_len, batch_size, sequence_dim), dtype=floatX)
+    seq_values = numpy.zeros((seq_len, batch_size, attended_dim), dtype=floatX)
     states_values = numpy.zeros((batch_size, state_dim), dtype=floatX)
     mask_values = numpy.zeros((seq_len, batch_size), dtype=floatX)
     # randomly generate a sensible mask
@@ -49,7 +49,7 @@ def test_sequence_content_attention():
     glimpses_values, weight_values = theano.function(
         [sequences, states, mask], [glimpses, weights])(
             seq_values, states_values, mask_values)
-    assert glimpses_values.shape == (batch_size, sequence_dim)
+    assert glimpses_values.shape == (batch_size, attended_dim)
     assert weight_values.shape == (batch_size, seq_len)
     assert numpy.all(weight_values >= 0)
     assert numpy.all(weight_values <= 1)
@@ -70,7 +70,7 @@ def test_attention_recurrent():
     wrapped = SimpleRecurrent(dim, Identity())
     attention = SequenceContentAttention(
         state_names=wrapped.apply.states,
-        sequence_dim=attended_dim, match_dim=attended_dim)
+        attended_dim=attended_dim, match_dim=attended_dim)
     recurrent = AttentionRecurrent(wrapped, attention, seed=1234)
     recurrent.weights_init = IsotropicGaussian(0.5)
     recurrent.biases_init = Constant(0)

--- a/tests/bricks/test_sequence_generators.py
+++ b/tests/bricks/test_sequence_generators.py
@@ -180,7 +180,7 @@ def test_with_attention():
     transition = TestTransition(
         dim=inp_dim, attended_dim=attended_dim, activation=Identity())
     attention = SequenceContentAttention(
-        transition.apply.states, match_dim=inp_dim)
+        state_names=transition.apply.states, match_dim=inp_dim)
     generator = SequenceGenerator(
         LinearReadout(
             readout_dim=inp_dim,

--- a/tests/bricks/test_sequence_generators.py
+++ b/tests/bricks/test_sequence_generators.py
@@ -183,7 +183,9 @@ def test_with_attention():
         transition.apply.states, match_dim=inp_dim)
     generator = SequenceGenerator(
         LinearReadout(
-            readout_dim=inp_dim, source_names=["states", "glimpses"],
+            readout_dim=inp_dim,
+            source_names=[transition.apply.states[0],
+                          attention.take_glimpses.outputs[0]],
             emitter=TestEmitter()),
         transition=transition,
         attention=attention,


### PR DESCRIPTION
A few goals I wanted to rich:

- free `AttentionRecurrent` from all sequence related terminology

- move reusable logic from `SequenceContentAttention` into a more generic class, since there will be more sequence attention mechanisms

On the way there were a few renamings as well.