### PR TITLE
LinearMaxout uses configuration from children

### DIFF
--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -358,6 +358,8 @@ class LinearMaxout(Initializable, Feedforward):
 
     @property
     def output_dim(self):
+        if self.linear_transformation.output_dim and self.num_pieces:
+            return self.linear_transformation.output_dim // self.num_pieces
         return self._output_dim
 
     @output_dim.setter

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -358,11 +358,13 @@ class LinearMaxout(Initializable, Feedforward):
 
     @property
     def output_dim(self):
-        return self.linear_transformation.output_dim // self.num_pieces
+        return self._output_dim
 
     @output_dim.setter
     def output_dim(self, value):
-        self.linear_transformation.output_dim = value * self.num_pieces
+        self._output_dim = value
+        if value and self.num_pieces:
+            self.linear_transformation.output_dim = value * self.num_pieces
 
     @property
     def num_pieces(self):
@@ -371,6 +373,8 @@ class LinearMaxout(Initializable, Feedforward):
     @num_pieces.setter
     def num_pieces(self, value):
         self.maxout_transformation.num_pieces = value
+        if self.output_dim:
+            self.linear_transformation.output_dim = self.output_dim * value
 
     @application(inputs=['input_'], outputs=['output'])
     def apply(self, input_):

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -339,10 +339,10 @@ class LinearMaxout(Initializable, Feedforward):
     @lazy
     def __init__(self, input_dim, output_dim, num_pieces, **kwargs):
         super(LinearMaxout, self).__init__(**kwargs)
-        self.linear_transformation = Linear()
-        self.maxout_transformation = Maxout()
-        self.children = [self.linear_transformation,
-                         self.maxout_transformation]
+        self.linear = Linear()
+        self.maxout = Maxout()
+        self.children = [self.linear,
+                         self.maxout]
 
         self.input_dim = input_dim
         self.output_dim = output_dim
@@ -350,15 +350,15 @@ class LinearMaxout(Initializable, Feedforward):
 
     @property
     def input_dim(self):
-        return self.linear_transformation.input_dim
+        return self.linear.input_dim
 
     @input_dim.setter
     def input_dim(self, value):
-        self.linear_transformation.input_dim = value
+        self.linear.input_dim = value
 
     def _push_allocation_config(self):
-        self.linear_transformation.output_dim = self.output_dim * self.num_pieces
-        self.maxout_transformation.num_pieces = self.num_pieces
+        self.linear.output_dim = self.output_dim * self.num_pieces
+        self.maxout.num_pieces = self.num_pieces
 
     @application(inputs=['input_'], outputs=['output'])
     def apply(self, input_):
@@ -375,8 +375,8 @@ class LinearMaxout(Initializable, Feedforward):
             The transformed input
 
         """
-        pre_activation = self.linear_transformation.apply(input_)
-        output = self.maxout_transformation.apply(pre_activation)
+        pre_activation = self.linear.apply(input_)
+        output = self.maxout.apply(pre_activation)
         return output
 
 

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -491,7 +491,8 @@ class Sequence(Brick):
 
     Parameters
     ----------
-    application_methods : list of :class:`.BoundApplication` to apply
+    application_methods : list
+        List of :class:`.BoundApplication` to apply
 
     """
     def __init__(self, application_methods, **kwargs):
@@ -520,7 +521,15 @@ class Sequence(Brick):
 
 
 class FeedforwardSequence(Sequence, Feedforward):
-    """A sequence where the first and last bricks are feedforward."""
+    """A sequence where the first and last bricks are feedforward.
+
+    Parameters
+    ----------
+    application_methods : list
+        List of :class:`.BoundApplication` to apply. The first and last
+        application method should belong to a :class:`Feedforward` brick.
+
+    """
     @property
     def input_dim(self):
         return self.children[0].input_dim


### PR DESCRIPTION
@rizar @dwf 

So this approach is slightly more wordy than what it was, but it removes the problems we have of configuration of parents and children diverging i.e. the behaviour I talked about in https://github.com/bartvm/blocks/pull/414/files#r25870737

I can do a similar thing for e.g. the MLP brick.