### PR TITLE
Fixed arguments in Dump

### DIFF
--- a/blocks/extensions/saveload.py
+++ b/blocks/extensions/saveload.py
@@ -123,7 +123,7 @@ class Dump(SimpleExtension):
         super(Dump, self).__init__(**kwargs)
         self.manager = MainLoopDumpManager(state_path)
 
-    def do(self, callback_name, **kwargs):
+    def do(self, callback_name, *args, **kwargs):
         try:
             self.main_loop.log.current_row[SAVED_TO] = (
                 self.manager.folder)


### PR DESCRIPTION
Now it is possible to run `Dump` extension before/after a batch.