### PR TITLE
Switch from dicts to lists for dimensions

### DIFF
--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -91,17 +91,17 @@ class AbstractAttention(Brick):
 
     Parameters
     ----------
-    state_names : list of str
+    state_names : list
         The names of the network states.
-    state_dims : dict
-        The {name: int} dictionary of state dimensions.
+    state_dims : list
+        The state dimensions corresponding to `state_names`.
     attended_dim : int
         The dimension of the attended.
 
     Attributes
     ----------
-    state_names : list of str
-    state_dims : dict
+    state_names : list
+    state_dims : list
     attended_dim : int
 
     """
@@ -325,8 +325,8 @@ class SequenceContentAttention(GenericSequenceAttention, Initializable):
 
     def _push_allocation_config(self):
         self.state_transformers.input_dims = self.state_dims
-        self.state_transformers.output_dims = {name: self.match_dim
-                                               for name in self.state_names}
+        self.state_transformers.output_dims = [self.match_dim
+                                               for name in self.state_names]
         self.attended_transformer.input_dim = self.attended_dim
         self.attended_transformer.output_dim = self.match_dim
         self.energy_computer.input_dim = self.match_dim
@@ -567,12 +567,12 @@ class AttentionRecurrent(AbstractAttentionRecurrent, Initializable):
         self.children = [self.transition, self.attention, self.distribute]
 
     def _push_allocation_config(self):
-        self.attention.state_dims = self.transition.get_dims(self._state_names)
+        self.attention.state_dims = self.transition.get_dims(
+            self.attention.state_names)
         self.attention.attended_dim = self.get_dim(self.attended_name)
         self.distribute.source_dim = self.attention.get_dim(
             self.distribute.source_name)
-        self.distribute.target_dims = dict_subset(
-            self.transition.get_dims(self._sequence_names),
+        self.distribute.target_dims = self.transition.get_dims(
             self.distribute.target_names)
 
     @application

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -746,20 +746,20 @@ class Brick(Annotation):
                          .format(name))
 
     def get_dims(self, names):
-        """Get dictionary of dimensions for a set of input/output variables.
+        """Get list of dimensions for a set of input/output variables.
 
         Parameters
         ----------
-        names : list of str
-            The dictionary of variable names.
+        names : list
+            The variable names.
 
         Returns
         -------
-        dims : dict
-            Dictionary of (variable name, variable dimension) pairs.
+        dims : list
+            The dimensions of the sources.
 
         """
-        return {name: self.get_dim(name) for name in names}
+        return [self.get_dim(name) for name in names]
 
 
 def lazy(func):

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -98,7 +98,7 @@ class WordReverser(Initializable):
         fork = Fork([name for name in encoder.prototype.apply.sequences
                     if name != 'mask'])
         fork.input_dim = dimension
-        fork.output_dims = {name: dimension for name in fork.input_names}
+        fork.output_dims = [dimension for name in fork.input_names]
         lookup = LookupTable(alphabet_size, dimension)
         transition = SimpleRecurrent(
             activation=Tanh(),

--- a/tests/bricks/test_attention.py
+++ b/tests/bricks/test_attention.py
@@ -26,7 +26,7 @@ def test_sequence_content_attention():
     match_dim = 4
 
     attention = SequenceContentAttention(
-        state_names=["states"], state_dims={"states": state_dim},
+        state_names=["states"], state_dims=[state_dim],
         attended_dim=attended_dim, match_dim=match_dim,
         weights_init=IsotropicGaussian(0.5),
         biases_init=Constant(0))

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -402,9 +402,8 @@ def test_sequence_variable_outputs():
                       biases_init=Constant(1))
 
     fork = Fork(input_dim=8, output_names=['linear_2_1', 'linear_2_2'],
-                output_dims=dict(linear_2_1=4, linear_2_2=5),
-                prototype=Linear(), weights_init=Constant(3),
-                biases_init=Constant(4))
+                output_dims=[4, 5], prototype=Linear(),
+                weights_init=Constant(3), biases_init=Constant(4))
     sequence = Sequence([linear_1.apply, fork.apply])
     sequence.initialize()
     y_1, y_2 = sequence.apply(x)
@@ -423,13 +422,11 @@ def test_sequence_variable_inputs():
     x, y = tensor.matrix(), tensor.matrix()
 
     parallel_1 = Parallel(input_names=['input_1', 'input_2'],
-                          input_dims=dict(input_1=4, input_2=5),
-                          output_dims=dict(input_1=3, input_2=2),
+                          input_dims=[4, 5], output_dims=[3, 2],
                           prototype=Linear(), weights_init=Constant(2),
                           biases_init=Constant(1))
     parallel_2 = Parallel(input_names=['input_1', 'input_2'],
-                          input_dims=dict(input_1=3, input_2=2),
-                          output_dims=dict(input_1=5, input_2=4),
+                          input_dims=[3, 2], output_dims=[5, 4],
                           prototype=Linear(), weights_init=Constant(2),
                           biases_init=Constant(1))
     sequence = Sequence([parallel_1.apply, parallel_2.apply])


### PR DESCRIPTION
Fixes #453. Also see https://github.com/bartvm/blocks/issues/453#issuecomment-78380525.

This PR switches from using dicts to store dimension information to using lists, for two principal reasons:

* Shorter function/constructor calls
* No redundant data; this is safer since there was no guarantee that the names in e.g. `self.source_names` and `self.source_dims` matched at all. There is still a chance that the lists aren't of the same length right now, but I think that eventually we should move to a `safe_zip` implementation like in Pylearn2 which would catch those errors.