### PR TITLE
Equizip

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -9,7 +9,7 @@ from six import add_metaclass
 from theano import tensor
 
 from blocks.graph import ComputationGraph
-from blocks.utils import dict_subset, named_copy, shared_floatx
+from blocks.utils import dict_subset, named_copy, shared_floatx, equizip
 from blocks.theano_expressions import l2_norm
 
 logger = logging.getLogger(__name__)
@@ -193,8 +193,8 @@ class GradientDescent(DifferentiableCostMinimizer):
         if not self.gradients:
             logger.info("Taking the cost gradient")
             self.gradients = dict(
-                zip(self.params, tensor.grad(self.cost, self.params,
-                                             known_grads=known_grads)))
+                equizip(self.params, tensor.grad(self.cost, self.params,
+                                                 known_grads=known_grads)))
             logger.info("The cost gradient computation graph is built")
         else:
             if known_grads:
@@ -289,9 +289,9 @@ class StepRule(object):
         """
         parameter_wise = [self.compute_step(param, previous_steps[param])
                           for param in previous_steps]
-        (steps, updates) = zip(*parameter_wise)
+        steps, updates = equizip(*parameter_wise)
         steps = OrderedDict((param, step) for param, step
-                            in zip(previous_steps.keys(), steps))
+                            in equizip(previous_steps.keys(), steps))
         updates = list(itertools.chain(*updates))
         return steps, updates
 

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -10,7 +10,7 @@ from toolz import interleave
 from blocks import config
 from blocks.bricks.base import application, _Brick, Brick, lazy
 from blocks.roles import add_role, WEIGHTS, BIASES
-from blocks.utils import pack, shared_floatx_nans
+from blocks.utils import pack, shared_floatx_nans, equizip
 
 logger = logging.getLogger(__name__)
 
@@ -621,8 +621,9 @@ class MLP(Sequence, Initializable, Feedforward):
     def _push_allocation_config(self):
         if not len(self.dims) - 1 == len(self.linear_transformations):
             raise ValueError
-        for input_dim, output_dim, layer in zip(self.dims[:-1], self.dims[1:],
-                                                self.linear_transformations):
+        for input_dim, output_dim, layer in \
+                equizip(self.dims[:-1], self.dims[1:],
+                        self.linear_transformations):
             layer.input_dim = input_dim
             layer.output_dim = output_dim
             layer.use_bias = self.use_bias

--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -5,7 +5,7 @@ from theano import tensor
 
 from blocks.bricks import Initializable, Linear
 from blocks.bricks.base import lazy, application
-from blocks.utils import pack
+from blocks.utils import pack, equizip
 
 
 class Parallel(Initializable):
@@ -81,7 +81,7 @@ class Parallel(Initializable):
         self.children = self.transforms
 
     def _push_allocation_config(self):
-        for name, transform in zip(self.input_names, self.transforms):
+        for name, transform in equizip(self.input_names, self.transforms):
             transform.input_dim = self.input_dims[name]
             transform.output_dim = self.output_dims[name]
 
@@ -90,7 +90,7 @@ class Parallel(Initializable):
         args = args + tuple(kwargs[name] for name in
                             self.input_names[len(args):])
         return [transform.apply(arg) for arg, transform
-                in zip(args, self.transforms)]
+                in equizip(args, self.transforms)]
 
     @apply.property('inputs')
     def apply_inputs(self):

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -12,7 +12,7 @@ from blocks.bricks.base import Application, application, Brick, lazy
 from blocks.initialization import NdarrayInitialization
 from blocks.roles import add_role, WEIGHTS, BIASES
 from blocks.utils import (pack, shared_floatx_nans, dict_union, dict_subset,
-                          is_shared_variable)
+                          is_shared_variable, equizip)
 
 logger = logging.getLogger()
 
@@ -185,7 +185,7 @@ def recurrent(*args, **kwargs):
                 args = list(args)
                 arg_names = (list(sequences_given) + list(states_given) +
                              list(contexts_given))
-                kwargs = dict(zip(arg_names, args))
+                kwargs = dict(equizip(arg_names, args))
                 kwargs.update(rest_kwargs)
                 outputs = getattr(brick, application_function.__name__)(
                     iterate=False, **kwargs)
@@ -616,4 +616,4 @@ class Bidirectional(Initializable):
                     self.children[1].apply(reverse=True, as_list=True,
                                            *args, **kwargs)]
         return [tensor.concatenate([f, b], axis=2)
-                for f, b in zip(forward, backward)]
+                for f, b in equizip(forward, backward)]

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -11,7 +11,7 @@ from blocks.bricks.lookup import LookupTable
 from blocks.bricks.recurrent import recurrent
 from blocks.bricks.attention import (
     AbstractAttentionRecurrent, AttentionRecurrent)
-from blocks.utils import dict_union, dict_subset
+from blocks.utils import dict_union, dict_subset, equizip
 
 
 class BaseSequenceGenerator(Initializable):
@@ -377,14 +377,14 @@ class LinearReadout(Readout, Initializable):
 
     def _push_allocation_config(self):
         super(LinearReadout, self)._push_allocation_config()
-        for name, projector in zip(self.source_names, self.projectors):
+        for name, projector in equizip(self.source_names, self.projectors):
             projector.input_dim = self.source_dims[name]
             projector.output_dim = self.readout_dim
 
     @application
     def readout(self, **kwargs):
         projections = [projector.apply(kwargs[name]) for name, projector in
-                       zip(self.source_names, self.projectors)]
+                       equizip(self.source_names, self.projectors)]
         if len(projections) == 1:
             return projections[0]
         return sum(projections[1:], projections[0])

--- a/blocks/graph.py
+++ b/blocks/graph.py
@@ -13,7 +13,7 @@ from toolz import unique
 from blocks import config
 from blocks.roles import add_role, has_roles, AUXILIARY, PARAMETER
 from blocks.utils import (is_graph_input, is_shared_variable, dict_union,
-                          shared_like)
+                          shared_like, equizip)
 
 logger = logging.getLogger(__name__)
 
@@ -189,11 +189,12 @@ class ComputationGraph(object):
                           if hasattr(var.tag, "roles") and
                           not is_shared_variable(var)]
         value_holders = [shared_like(var) for var in role_variables]
-        function = self.get_theano_function(zip(value_holders, role_variables))
+        function = self.get_theano_function(equizip(value_holders,
+                                                    role_variables))
         function(*(data[input_.name] for input_ in self.inputs))
         return OrderedDict([(var, value_holder.get_value(borrow=True))
-                            for var, value_holder in zip(role_variables,
-                                                         value_holders)])
+                            for var, value_holder in equizip(role_variables,
+                                                             value_holders)])
 
     def has_inputs(self, variable):
         """Check if a variable depends on input variables.

--- a/blocks/monitoring/evaluators.py
+++ b/blocks/monitoring/evaluators.py
@@ -7,7 +7,7 @@ from theano import tensor
 from blocks.utils import dict_subset
 from blocks.monitoring.aggregation import _DataIndependent, Mean, TakeLast
 from blocks.graph import ComputationGraph
-from blocks.utils import reraise_as
+from blocks.utils import equizip, reraise_as
 
 logger = logging.getLogger()
 
@@ -133,7 +133,7 @@ class AggregationBuffer(object):
             raise Exception("To readout you must first initialize, then"
                             "process batches!")
         ret_vals = self._readout_fun()
-        return dict(zip(self.variable_names, ret_vals))
+        return dict(equizip(self.variable_names, ret_vals))
 
 
 class DatasetEvaluator(object):

--- a/blocks/search.py
+++ b/blocks/search.py
@@ -10,6 +10,7 @@ from blocks.bricks.sequence_generators import SequenceGenerator
 from blocks.filter import VariableFilter, get_application_call, get_brick
 from blocks.graph import ComputationGraph
 from blocks.roles import INPUT, OUTPUT
+from blocks.utils import equizip
 
 floatX = config.floatX
 
@@ -99,7 +100,7 @@ class BeamSearch(object):
         initial_states = [
             self.generator.initial_state(
                 name, self.beam_size,
-                **dict(zip(self.context_names, self.contexts)))
+                **dict(equizip(self.context_names, self.contexts)))
             for name in self.state_names]
         self.initial_state_computer = function(
             self.contexts, initial_states, on_unused_input='ignore')
@@ -151,7 +152,7 @@ class BeamSearch(object):
         """
         contexts = self.context_computer(*[inputs[var]
                                            for var in self.inputs])
-        return OrderedDict(zip(self.context_names, contexts))
+        return OrderedDict(equizip(self.context_names, contexts))
 
     def compute_initial_states(self, contexts):
         """Computes initial states.
@@ -168,7 +169,7 @@ class BeamSearch(object):
 
         """
         init_states = self.initial_state_computer(*list(contexts.values()))
-        return OrderedDict(zip(self.state_names, init_states))
+        return OrderedDict(equizip(self.state_names, init_states))
 
     def compute_logprobs(self, contexts, states):
         """Compute log probabilities of all possible outputs.
@@ -210,7 +211,7 @@ class BeamSearch(object):
         input_states = [states[name] for name in self.input_state_names]
         next_values = self.next_state_computer(*(list(contexts.values()) +
                                                  input_states + [outputs]))
-        return OrderedDict(zip(self.state_names, next_values))
+        return OrderedDict(equizip(self.state_names, next_values))
 
     @staticmethod
     def _smallest(matrix, k, only_first_row=False):
@@ -336,6 +337,6 @@ class BeamSearch(object):
     def result_to_lists(result):
         outputs, masks, costs = [array.T for array in result]
         outputs = [list(output[:mask.sum()])
-                   for output, mask in zip(outputs, masks)]
+                   for output, mask in equizip(outputs, masks)]
         costs = list(costs.T.sum(axis=0))
         return outputs, costs

--- a/blocks/select.py
+++ b/blocks/select.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 import six
 
 from blocks.bricks.base import Brick
-from blocks.utils import dict_union
+from blocks.utils import dict_union, equizip
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ class Path(object):
             raise ValueError
 
         nodes = []
-        for separator, part in zip(separators, parts):
+        for separator, part in equizip(separators, parts):
             if separator == Path.separator:
                 nodes.append(Path.BrickName(part))
             elif Path.param_separator == Path.param_separator:

--- a/blocks/utils.py
+++ b/blocks/utils.py
@@ -70,6 +70,45 @@ def unpack(arg, singleton=False):
         return arg
 
 
+class IterableLengthMismatch(Exception):
+    """Custom error for equizip."""
+
+
+def equizip(*iterables):
+    r"""Like zip but ensure iterables are of equal length.
+
+    .. warning::
+
+       Behaves like :func:`zip` in Python 3 i.e. as :class:`itertools.izip`
+       in Python 2.
+
+    Parameters
+    ----------
+    \*iterables
+        A collection of iterables to be zipped.
+
+    """
+    iterators = [iter(iterable) for iterable in iterables]
+    while True:
+        try:
+            first_value = next(iterators[0])
+            try:
+                other_values = [next(iterator) for iterator in iterators[1:]]
+            except StopIteration:
+                raise IterableLengthMismatch
+            else:
+                yield tuple([first_value] + other_values)
+        except StopIteration:
+            for iterator in iterators[1:]:
+                try:
+                    next(iterator)
+                except StopIteration:
+                    pass
+                else:
+                    raise IterableLengthMismatch
+            raise
+
+
 def shared_floatx_zeros(shape, **kwargs):
     r"""Creates a shared variable array filled with zeros.
 

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -35,7 +35,7 @@ from blocks.extensions.monitoring import TrainingDataMonitoring
 from blocks.extensions.plot import Plot
 from blocks.main_loop import MainLoop
 from blocks.filter import VariableFilter
-from blocks.utils import named_copy, dict_union
+from blocks.utils import named_copy, dict_union, equizip
 
 from blocks.search import BeamSearch
 
@@ -318,7 +318,7 @@ def main(mode, save_path, num_batches, data_path=None):
                 numpy.repeat(numpy.array(encoded_input)[:, None],
                              batch_size, axis=1))
             messages = []
-            for sample, cost in zip(samples, costs):
+            for sample, cost in equizip(samples, costs):
                 message = "({})".format(cost)
                 message += "".join(code2char[code] for code in sample)
                 if sample == target:

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -3,10 +3,11 @@ import tempfile
 import numpy
 import theano
 
-from examples.sqrt import main as sqrt_example
 from blocks.dump import (
     load_parameter_values, save_parameter_values,
     MainLoopDumpManager)
+from blocks.utils import equizip
+from examples.sqrt import main as sqrt_example
 from tests import silence_printing
 
 floatX = theano.config.floatX
@@ -19,7 +20,7 @@ def test_save_load_parameter_values():
     loaded_values = sorted(list(load_parameter_values(filename).items()),
                            key=lambda tuple_: tuple_[0])
     assert len(loaded_values) == len(param_values)
-    for old, new in zip(param_values, loaded_values):
+    for old, new in equizip(param_values, loaded_values):
         assert old[0] == new[0]
         assert numpy.all(old[1] == new[1])
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 from numpy.testing import assert_raises
 from theano import tensor
 
-from blocks.utils import check_theano_variable, unpack
+from blocks.utils import (check_theano_variable, unpack, equizip,
+                          IterableLengthMismatch)
 
 
 def test_unpack():
@@ -20,3 +21,10 @@ def test_check_theano_variable():
                   tensor.vector(), 2, 'float')
     assert_raises(ValueError, check_theano_variable,
                   tensor.vector(), 1, 'int')
+
+
+def test_equizip():
+    assert_raises(IterableLengthMismatch, list, equizip(range(4), range(5)))
+    assert_raises(IterableLengthMismatch, list, equizip(range(4), range(3)))
+    assert (list(equizip((i for i in range(2)), (i for i in range(2)))) ==
+            [(0, 0), (1, 1)])


### PR DESCRIPTION
Behaves like (i)zip but raises an error if two iterables aren't of the same length. Name shamelessly stolen from the Python mailing list (https://mail.python.org/pipermail/python-3000/2006-March/000160.html), but I think it sounds better than Pylearn2's `safe_zip`.

Right now I get two errors in `test_sequence_generator` and `test_integer_sequence_generator` because they request outputs `as_dict`, but there are more outputs than are named. This raises another question: Should we check if the outputs are named, and if they are, should we raise an error if the lengths don't match? Right now this error would only occur if `as_dict=True` is passed, but we might as well check it by default.