### PR TITLE
Make default bekeh server configurable via .blocksrc

### DIFF
--- a/blocks/config_parser.py
+++ b/blocks/config_parser.py
@@ -40,6 +40,12 @@ The following configurations are supported:
    is pickling or unpickling a complex structure with lots of objects, such
    as a big Theano computation graph.
 
+.. option:: bokeh_server
+
+   The default URL to use when contacting a Bokeh server for live plotting.
+   This setting is used by the :class:`~blocks.extensions.plot.Plot`. The
+   default is ``http://localhost:5006/``.
+
 .. _YAML: http://yaml.org/
 .. _environment variables:
    https://en.wikipedia.org/wiki/Environment_variable
@@ -136,5 +142,6 @@ config = Configuration()
 # Define configuration options
 config.add_config('default_seed', type_=int, default=1)
 config.add_config('recursion_limit', type_=int, default=10000)
+config.add_config('bokeh_server', type_=str, default='http://localhost:5006/')
 
 config.load_yaml()

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -10,6 +10,8 @@ try:
 except ImportError:
     BOKEH_AVAILABLE = False
 
+
+from blocks import config
 from blocks.extensions import SimpleExtension
 
 logger = logging.getLogger(__name__)
@@ -61,7 +63,9 @@ class Plot(SimpleExtension):
     server_url : str, optional
         Url of the bokeh-server. Ex: when starting the bokeh-server with
         ``bokeh-server --ip 0.0.0.0`` at ``alice``, server_url should be
-        ``http://alice:5006``.
+        ``http://alice:5006``. When not specified the default configured
+        by ``bokeh_server`` in ``.blocksrc`` will be used. Defaults to
+        ``http://localhost:5006/``.
 
     """
     # Tableau 10 colors
@@ -69,9 +73,13 @@ class Plot(SimpleExtension):
               '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf']
 
     def __init__(self, document, channels, open_browser=False,
-                 start_server=False, server_url='default', **kwargs):
+                 start_server=False, server_url=None, **kwargs):
         if not BOKEH_AVAILABLE:
             raise ImportError
+
+        if server_url is None:
+            server_url = config.bokeh_server
+
         self.plots = {}
         self.start_server = start_server
         self.document = document


### PR DESCRIPTION
I think it makes sense to have thins configurable -- being forced to add an explicit ``server_url`` to the Plot extensions in all main scripts makes these scripts clearly less portable between systems.
 