### PR TITLE
Fix ConvolutionalLayer batch size bug

### DIFF
--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -260,12 +260,13 @@ class ConvolutionalLayer(Sequence, Initializable):
         self.pooling_size = pooling_size
         self.conv_step = conv_step
         self.pooling_step = pooling_step
+        self.batch_size = batch_size
         self.border_mode = border_mode
         self.image_size = image_size
 
     def _push_allocation_config(self):
         for attr in ['filter_size', 'num_filters', 'num_channels',
-                     'border_mode', 'image_size']:
+                     'batch_size', 'border_mode', 'image_size']:
             setattr(self.convolution, attr, getattr(self, attr))
         self.convolution.step = self.conv_step
         self.convolution._push_allocation_config()
@@ -276,6 +277,7 @@ class ConvolutionalLayer(Sequence, Initializable):
         self.pooling.input_dim = pooling_input_dim
         self.pooling.pooling_size = self.pooling_size
         self.pooling.step = self.pooling_step
+        self.pooling.batch_size = self.batch_size
 
     def get_dim(self, name):
         if name == 'input_':

--- a/tests/bricks/test_conv.py
+++ b/tests/bricks/test_conv.py
@@ -1,7 +1,7 @@
 import numpy
 
 import theano
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 from theano import tensor
 from theano import function
 
@@ -68,6 +68,7 @@ def test_convolutional_layer():
     conv = ConvolutionalLayer(activation, filter_size, num_filters,
                               (pooling_size, pooling_size),
                               num_channels, image_size=(17, 13),
+                              batch_size=batch_size,
                               weights_init=Constant(1.),
                               biases_init=Constant(5.))
     conv.initialize()
@@ -79,6 +80,9 @@ def test_convolutional_layer():
                        dtype=theano.config.floatX)
     assert_allclose(func(x_val), numpy.prod(filter_size) * num_channels *
                     numpy.ones((batch_size, num_filters, 5, 4)) + 5)
+
+    assert_equal(conv.convolution.batch_size, batch_size)
+    assert_equal(conv.pooling.batch_size, batch_size)
 
 
 def test_convolutional_sequence():


### PR DESCRIPTION
The batch size was not pushed to the `ConvolutionalLayer`'s convolution and pooling bricks.