### PR TITLE
WIP: Write a bit of docs and make sequence generator more standard

### DIFF
--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -8,8 +8,8 @@ element is fed back into the recurrent network state. Sometimes
 also an attention mechanism is used to condition sequence generation
 on some structured input like another sequence or an image.
 
-This module provides :class:`SequenceGenerator` that builds a sequence generating
-network from three main components:
+This module provides :class:`SequenceGenerator` that builds a sequence
+generating network from three main components:
 
 * a core recurrent transition, e.g. :class:`~blocks.bricks.recurrent.LSTM`
   or :class:`~blocks.bricks.recurrent.GRU`
@@ -275,7 +275,7 @@ class BaseSequenceGenerator(Initializable):
             **dict_union(next_states, next_glimpses, contexts))
         next_outputs = self.readout.emit(next_readouts)
         next_costs = self.readout.cost(next_readouts, next_outputs)
-        return (list(next_states.values())+ [next_outputs] +
+        return (list(next_states.values()) + [next_outputs] +
                 list(next_glimpses.values()) + [next_costs])
 
     @generate.delegate

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -98,7 +98,7 @@ class BaseSequenceGenerator(Initializable):
       average of the annotations.
 
     * For speech recognition we would have two: the weighted average,
-      the alignment and the alignment.
+      and the alignment.
 
     Parameters
     ----------

--- a/tests/bricks/test_sequence_generators.py
+++ b/tests/bricks/test_sequence_generators.py
@@ -87,8 +87,8 @@ def test_sequence_generator():
     assert states.shape == (n_steps, batch_size, dim)
     assert outputs.shape == (n_steps, batch_size, output_dim)
     assert costs.shape == (n_steps, batch_size)
-    assert_allclose(outputs.sum(), -0.33683, rtol=1e-5)
-    assert_allclose(states.sum(), 15.7909, rtol=1e-5)
+    assert_allclose(outputs.sum(), -0.61249, rtol=1e-5)
+    assert_allclose(states.sum(), 15.5803, rtol=1e-5)
     # There is no generation cost in this case, since generation is
     # deterministic
     assert_allclose(costs.sum(), 0.0)
@@ -130,13 +130,13 @@ def test_integer_sequence_generator():
     m_test = numpy.ones((n_steps, batch_size), dtype=floatX)
     costs_val = costs_fun(y_test, m_test)[0]
     assert costs_val.shape == (n_steps, batch_size)
-    assert_allclose(costs_val.sum(), 482.827, rtol=1e-5)
+    assert_allclose(costs_val.sum(), 482.835, rtol=1e-5)
 
     # Test 'cost' method
     cost = generator.cost(y, mask)
     assert cost.ndim == 0
-    cost_val = theano.function([y, mask], [cost])(y_test, m_test)
-    assert_allclose(cost_val, 16.0942, rtol=1e-5)
+    cost_val = theano.function([y, mask], [cost])(y_test, m_test)[0]
+    assert_allclose(cost_val, 16.0945, rtol=1e-5)
 
     # Test 'AUXILIARY' variable 'per_sequence_element' in 'cost' method
     cg = ComputationGraph([cost])
@@ -147,7 +147,7 @@ def test_integer_sequence_generator():
                    if el.name == aux_var_name][0]
     assert cost_per_el.ndim == 0
     cost_per_el_val = theano.function([y, mask], [cost_per_el])(y_test, m_test)
-    assert_allclose(cost_per_el_val, 1.60942, rtol=1e-5)
+    assert_allclose(cost_per_el_val, 1.60945, rtol=1e-5)
 
     # Test generate
     states, outputs, costs = generator.generate(
@@ -160,9 +160,9 @@ def test_integer_sequence_generator():
     assert outputs_val.shape == (n_steps, batch_size)
     assert outputs_val.dtype == 'int64'
     assert costs_val.shape == (n_steps, batch_size)
-    assert_allclose(states_val.sum(), -17.91811, rtol=1e-5)
-    assert_allclose(costs_val.sum(), 482.863, rtol=1e-5)
-    assert outputs_val.sum() == 630
+    assert_allclose(states_val.sum(), -19.72, rtol=1e-5)
+    assert_allclose(costs_val.sum(), 482.852, rtol=1e-5)
+    assert_equal(outputs_val.sum(), 629)
 
     # Test masks agnostic results of cost
     cost1 = costs_fun([[1], [2]], [[1], [1]])[0]
@@ -251,7 +251,7 @@ def test_with_attention():
                              attended: attended_vals,
                              attended_mask: attended_mask_vals})
     assert costs_vals.shape == (inp_len, batch_size)
-    assert_allclose(costs_vals.sum(), 13.5042, rtol=1e-5)
+    assert_allclose(costs_vals.sum(), 13.5552, rtol=1e-5)
 
     # Test `generate` method
     results = (
@@ -266,13 +266,13 @@ def test_with_attention():
     assert glimpses_vals.shape == (n_steps, batch_size, attended_dim)
     assert weights_vals.shape == (n_steps, batch_size, attended_len)
     assert costs_vals.shape == (n_steps, batch_size)
-    assert_allclose(states_vals.sum(), 23.4172, rtol=1e-5)
+    assert_allclose(states_vals.sum(), 23.3370, rtol=1e-5)
     # There is no generation cost in this case, since generation is
     # deterministic
     assert_allclose(costs_vals.sum(), 0.0, rtol=1e-5)
     assert_allclose(weights_vals.sum(), 120.0, rtol=1e-5)
     assert_allclose(glimpses_vals.sum(), 199.2402, rtol=1e-5)
-    assert_allclose(outputs_vals.sum(), -11.6008, rtol=1e-5)
+    assert_allclose(outputs_vals.sum(), -11.5917, rtol=1e-5)
 
 
 def test_softmax_emitter_initial_outputs():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,7 +1,7 @@
 import numpy
 import theano
 from theano import tensor
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from blocks.graph import ComputationGraph
 from blocks.filter import VariableFilter
@@ -47,7 +47,7 @@ def test_beam_search():
     search = BeamSearch(10, samples)
     results, mask, costs = search.search(
         {inputs: input_vals}, 0, 3 * length, as_arrays=True)
-    assert results.sum() == 5084
+    assert_equal(results.sum(), 4506)
 
     true_costs = reverser.cost(
         input_vals, numpy.ones((length, beam_size), dtype=floatX),


### PR DESCRIPTION
My work in progress on fixing quirks of sequence generator. It seems like having `outputs_t` generated from `states_t`, not from `states_{t-1}` is the current standard and makes code easier.

On my way I am changing docs a bit, though this is not the main point of this PR.