### PR TITLE
Fix bug in ComputationGraph.replace

### DIFF
--- a/blocks/graph.py
+++ b/blocks/graph.py
@@ -205,8 +205,9 @@ class ComputationGraph(object):
         for node in apply_nodes_sorted:
             for input_ in node.inputs:
                 if input_ in replacements:
-                    replacement_keys_cur.append(input_)
-                    replacement_vals_cur.append(replacements[input_])
+                    if input_ not in replacement_keys_cur:
+                        replacement_keys_cur.append(input_)
+                        replacement_vals_cur.append(replacements[input_])
 
         # Add outputs of the computation graph
         for output in self.outputs:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -80,6 +80,16 @@ def test_replace():
     out_val = doubled_cg.outputs[0].eval({x: 2})
     assert out_val == 6.0
 
+def test_replace_multiple_inputs():
+    # Test if replace works on variables that are input to multiple nodes
+    x = tensor.scalar('x')
+    y = 2 * x
+    z = x + 1
+
+    cg = ComputationGraph([y, z]).replace({x: 0.5 * x})
+    assert_allclose(cg.outputs[0].eval({x: 1.0}), 1.0)
+    assert_allclose(cg.outputs[1].eval({x: 1.0}), 1.5)
+
 
 def test_apply_noise():
     x = tensor.scalar()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -80,6 +80,7 @@ def test_replace():
     out_val = doubled_cg.outputs[0].eval({x: 2})
     assert out_val == 6.0
 
+
 def test_replace_multiple_inputs():
     # Test if replace works on variables that are input to multiple nodes
     x = tensor.scalar('x')


### PR DESCRIPTION
If a variable to be replaced is an input to multiple nodes, the replacement is made multiple times, which is incorrect.