### PR TITLE
bugfix: all save_separately were concatenated in path of Checkpoint

### DIFF
--- a/blocks/extensions/saveload.py
+++ b/blocks/extensions/saveload.py
@@ -79,8 +79,8 @@ class Checkpoint(SimpleExtension):
             secure_pickle_dump(self.main_loop, path)
             for attribute in self.save_separately:
                 root, ext = os.path.splitext(path)
-                path = root + "_" + attribute + ext
-                secure_pickle_dump(getattr(self.main_loop, attribute), path)
+                outpath = root + "_" + attribute + ext
+                secure_pickle_dump(getattr(self.main_loop, attribute), outpath)
         except Exception:
             self.main_loop.log.current_row[SAVED_TO] = None
             raise


### PR DESCRIPTION
fix a minor bug Checkpoint in which the the attributs of save_separatly were accumulating one after the other in the path of the saved pkl. For example with save_separatly=['log','model'] then the path of the last pkl will be ..._log_model.pkl and not ..._model.pkl