### PR TITLE
New lazy decorator

### DIFF
--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -100,7 +100,7 @@ class Initializable(Brick):
     has_biases = True
     seed_rng = numpy.random.RandomState(config.default_seed)
 
-    @lazy
+    @lazy(initialization=['weights_init'])
     def __init__(self, weights_init, biases_init=None, use_bias=True,
                  seed=None, **kwargs):
         super(Initializable, self).__init__(**kwargs)
@@ -201,7 +201,7 @@ class Linear(Initializable, Feedforward):
     .. math:: f(\mathbf{x}) = \mathbf{W}\mathbf{x} + \mathbf{b}
 
     """
-    @lazy
+    @lazy(allocation=['input_dim', 'output_dim'])
     def __init__(self, input_dim, output_dim, **kwargs):
         super(Linear, self).__init__(**kwargs)
         self.input_dim = input_dim
@@ -268,7 +268,7 @@ class Linear(Initializable, Feedforward):
 
 class Bias(Feedforward, Initializable):
     """Add a bias (i.e. sum with a vector)."""
-    @lazy
+    @lazy(allocation=['dim'])
     def __init__(self, dim, **kwargs):
         super(Bias, self).__init__(**kwargs)
         self.dim = dim
@@ -335,7 +335,7 @@ class Maxout(Brick):
     for each output dimension the result with the highest value.
 
     """
-    @lazy
+    @lazy(allocation=['num_pieces'])
     def __init__(self, num_pieces, **kwargs):
         super(Maxout, self).__init__(**kwargs)
         self.num_pieces = num_pieces
@@ -385,7 +385,7 @@ class LinearMaxout(Initializable, Feedforward):
     See :class:`Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy(allocation=['input_dim', 'output_dim', 'num_pieces'])
     def __init__(self, input_dim, output_dim, num_pieces, **kwargs):
         super(LinearMaxout, self).__init__(**kwargs)
         self.linear = Linear()
@@ -631,7 +631,7 @@ class MLP(Sequence, Initializable, Feedforward):
     >>> mlp.initialize()
 
     """
-    @lazy
+    @lazy(allocation=['dims'])
     def __init__(self, activations, dims, **kwargs):
         self.activations = activations
 

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -622,7 +622,6 @@ class MLP(Sequence, Initializable, Feedforward):
     configuration to the child layers manually before initialization.
 
     >>> from blocks.initialization import IsotropicGaussian, Constant
-    >>> Brick.lazy = True
     >>> mlp = MLP(activations=[Tanh(), None], dims=[30, 20, 10],
     ...           weights_init=IsotropicGaussian(),
     ...           biases_init=Constant(1))

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -100,8 +100,8 @@ class Initializable(Brick):
     has_biases = True
     seed_rng = numpy.random.RandomState(config.default_seed)
 
-    @lazy(initialization=['weights_init'])
-    def __init__(self, weights_init, biases_init=None, use_bias=True,
+    @lazy()
+    def __init__(self, weights_init=None, biases_init=None, use_bias=True,
                  seed=None, **kwargs):
         super(Initializable, self).__init__(**kwargs)
         self.weights_init = weights_init

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -105,7 +105,7 @@ class AbstractAttention(Brick):
     attended_dim : int
 
     """
-    @lazy
+    @lazy(allocation=['state_names', 'state_dims', 'attended_dim'])
     def __init__(self, state_names, state_dims, attended_dim, **kwargs):
         self.state_names = state_names
         self.state_dims = state_dims
@@ -303,7 +303,7 @@ class SequenceContentAttention(GenericSequenceAttention, Initializable):
        Machine Translation by Jointly Learning to Align and Translate.
 
     """
-    @lazy
+    @lazy(allocation=['match_dim'])
     def __init__(self, match_dim, state_transformer=None,
                  attended_transformer=None, energy_computer=None, **kwargs):
         super(SequenceContentAttention, self).__init__(**kwargs)
@@ -414,7 +414,7 @@ class SequenceContentAttention(GenericSequenceAttention, Initializable):
 
 class ShallowEnergyComputer(Sequence, Initializable, Feedforward):
     """A simple energy computer: first tanh, then weighted sum."""
-    @lazy
+    @lazy()
     def __init__(self, **kwargs):
         super(ShallowEnergyComputer, self).__init__(
             [Tanh().apply, MLP([Identity()]).apply], **kwargs)

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -609,20 +609,15 @@ class Brick(Annotation):
         reset the parameters.
 
         """
+        if any(getattr(self, arg) is NoneAllocation
+               for arg in self.allocation_args):
+            raise ValueError('allocation config not set')
         if not self.allocation_config_pushed:
             self.push_allocation_config()
         for child in self.children:
             child.allocate()
         self.params = []
-        try:
-            self._allocate()
-        except Exception:
-            if self.lazy:
-                reraise_as("Lazy initialization is enabled, so please make "
-                           "sure you have set all the required configuration "
-                           "for this method call.")
-            else:
-                raise
+        self._allocate()
         self.allocated = True
 
     def _allocate(self):
@@ -649,21 +644,16 @@ class Brick(Annotation):
         call the :meth:`allocate` method in order to do so.
 
         """
+        if any(getattr(self, arg) is NoneInitialization
+               for arg in self.initialization_args):
+            raise ValueError('initialization config not set')
         if not self.allocated:
             self.allocate()
         if not self.initialization_config_pushed:
             self.push_initialization_config()
         for child in self.children:
             child.initialize()
-        try:
-            self._initialize()
-        except Exception:
-            if self.lazy:
-                reraise_as("Lazy initialization is enabled, so please make "
-                           "sure you have set all the required configuration "
-                           "for this method call.")
-            else:
-                raise
+        self._initialize()
         self.initialized = True
 
     def _initialize(self):

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -8,11 +8,10 @@ import six
 from six import add_metaclass
 from theano import tensor
 from theano.gof import Variable
-from toolz import first, merge_with
 
 from blocks.graph import add_annotation, Annotation
 from blocks.roles import add_role, PARAMETER, INPUT, OUTPUT
-from blocks.utils import pack, repr_attrs, reraise_as, unpack
+from blocks.utils import dict_union, pack, repr_attrs, reraise_as, unpack
 from blocks.utils.containers import AnnotatingList
 
 
@@ -797,19 +796,13 @@ def lazy(allocation=None, initialization=None):
         initialization = []
 
     def lazy_wrapper(init):
-        def strict_merge(values):
-            if len(values) > 1:
-                raise ValueError
-            return first(values)
-
         def lazy_init(*args, **kwargs):
             self = args[0]
             self.allocation_args = (getattr(self, 'allocation_args',
                                             []) + allocation)
             self.initialization_args = (getattr(self, 'initialization_args',
                                                 []) + initialization)
-            kwargs = merge_with(strict_merge, args_to_kwargs(args, init),
-                                kwargs)
+            kwargs = dict_union(args_to_kwargs(args, init), kwargs)
             for allocation_arg in allocation:
                 kwargs.setdefault(allocation_arg, NoneAllocation)
             for initialization_arg in initialization:

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -38,7 +38,7 @@ class Convolutional(Initializable):
         details. Defaults to 'valid'.
 
     """
-    @lazy
+    @lazy(allocation=['filter_size', 'num_filters', 'num_channels'])
     def __init__(self, filter_size, num_filters, num_channels, batch_size=None,
                  image_size=None, step=(1, 1), border_mode='valid', **kwargs):
         super(Convolutional, self).__init__(**kwargs)
@@ -137,7 +137,7 @@ class MaxPooling(Initializable, Feedforward):
         two dimensions will be used to calculate the output dimension.
 
     """
-    @lazy
+    @lazy(allocation=['pooling_size'])
     def __init__(self, pooling_size, step=None, input_dim=None, **kwargs):
         super(MaxPooling, self).__init__(**kwargs)
 
@@ -190,7 +190,7 @@ class ConvolutionalActivation(Sequence, Initializable):
     :class:`Convolutional` : For the documentation of other parameters.
 
     """
-    @lazy
+    @lazy(allocation=['filter_size', 'num_filters', 'num_channels'])
     def __init__(self, activation, filter_size, num_filters, num_channels,
                  batch_size=None, image_size=None, step=(1, 1),
                  border_mode='valid', **kwargs):
@@ -240,7 +240,7 @@ class ConvolutionalLayer(Sequence, Initializable):
     Uses max pooling.
 
     """
-    @lazy
+    @lazy(allocation=['filter_size', 'num_filters'])
     def __init__(self, activation, filter_size, num_filters, pooling_size,
                  num_channels, conv_step=(1, 1), pooling_step=None,
                  batch_size=None, image_size=None, border_mode='valid',
@@ -317,7 +317,7 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
     layer by the :meth:`~.Brick.push_allocation_config` method.
 
     """
-    @lazy
+    @lazy(allocation=['num_channels'])
     def __init__(self, layers, num_channels, batch_size=None, image_size=None,
                  **kwargs):
         self.layers = layers

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -240,7 +240,8 @@ class ConvolutionalLayer(Sequence, Initializable):
     Uses max pooling.
 
     """
-    @lazy(allocation=['filter_size', 'num_filters'])
+    @lazy(allocation=['filter_size', 'num_filters', 'pooling_size',
+                      'num_channels'])
     def __init__(self, activation, filter_size, num_filters, pooling_size,
                  num_channels, conv_step=(1, 1), pooling_step=None,
                  batch_size=None, image_size=None, border_mode='valid',

--- a/blocks/bricks/lookup.py
+++ b/blocks/bricks/lookup.py
@@ -22,7 +22,7 @@ class LookupTable(Initializable):
     """
     has_bias = False
 
-    @lazy
+    @lazy(allocation=['length', 'dim'])
     def __init__(self, length, dim, **kwargs):
         super(LookupTable, self).__init__(**kwargs)
         self.length = length

--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -56,7 +56,7 @@ class Parallel(Initializable):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy(allocation=['input_dims'])
     def __init__(self, input_names, input_dims, output_dims,
                  prototype=None, child_prefix=None, **kwargs):
         super(Parallel, self).__init__(**kwargs)
@@ -141,7 +141,7 @@ class Fork(Parallel):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy(allocation=['input_dim'])
     def __init__(self, output_names, input_dim,  prototype=None, **kwargs):
         self.output_names = output_names
         self.input_dim = input_dim
@@ -212,7 +212,7 @@ class Distribute(Fork):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy(allocation=['source_name', 'target_dims'])
     def __init__(self, target_names, source_name, target_dims, source_dim,
                  prototype=None, **kwargs):
         self.target_names = target_names
@@ -307,7 +307,7 @@ class Merge(Parallel):
     array([[ 11.,  11.]]...
 
     """
-    @lazy
+    @lazy(allocation=['input_dims', 'output_dim'])
     def __init__(self, input_names, input_dims, output_dim, **kwargs):
         self.output_dim = output_dim
         super(Merge, self).__init__(

--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -148,6 +148,7 @@ class Fork(Parallel):
 
         super(Fork, self).__init__(output_names, prototype=prototype,
                                    child_prefix="fork", **kwargs)
+        self.input_dims = None
 
     def _push_allocation_config(self):
         self.input_dims = [self.input_dim for name in self.output_names]

--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -56,7 +56,7 @@ class Parallel(Initializable):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy(allocation=['input_dims'])
+    @lazy(allocation=['input_dims', 'input_dims', 'output_dims'])
     def __init__(self, input_names, input_dims, output_dims,
                  prototype=None, child_prefix=None, **kwargs):
         super(Parallel, self).__init__(**kwargs)
@@ -212,7 +212,7 @@ class Distribute(Fork):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy(allocation=['source_name', 'target_dims'])
+    @lazy(allocation=['source_name', 'target_dims', 'source_dim'])
     def __init__(self, target_names, source_name, target_dims, source_dim,
                  prototype=None, **kwargs):
         self.target_names = target_names

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -252,7 +252,7 @@ class SimpleRecurrent(BaseRecurrent, Initializable):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy(allocation=['dim'])
     def __init__(self, dim, activation, **kwargs):
         super(SimpleRecurrent, self).__init__(**kwargs)
         self.dim = dim
@@ -338,7 +338,7 @@ class LSTM(BaseRecurrent, Initializable):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy(allocation=['dim'])
     def __init__(self, dim, activation=None, **kwargs):
         super(LSTM, self).__init__(**kwargs)
         self.dim = dim
@@ -464,7 +464,7 @@ class GatedRecurrent(BaseRecurrent, Initializable):
         for Statistical Machine Translation*, EMNLP (2014), pp. 1724-1734.
 
     """
-    @lazy
+    @lazy(allocation=['dim'])
     def __init__(self, dim, activation=None, gate_activation=None,
                  use_update_gate=True, use_reset_gate=True, **kwargs):
         super(GatedRecurrent, self).__init__(**kwargs)
@@ -605,7 +605,7 @@ class Bidirectional(Initializable):
     """
     has_bias = False
 
-    @lazy
+    @lazy()
     def __init__(self, prototype, **kwargs):
         super(Bidirectional, self).__init__(**kwargs)
         self.prototype = prototype

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -94,7 +94,7 @@ class BaseSequenceGenerator(Initializable):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy()
     def __init__(self, readout, transition, fork, **kwargs):
         super(BaseSequenceGenerator, self).__init__(**kwargs)
         self.readout = readout
@@ -367,7 +367,7 @@ class Readout(AbstractReadout, Initializable):
         change dimensions).
 
     """
-    @lazy
+    @lazy(allocation=['source_names', 'readout_dim'])
     def __init__(self, source_names, readout_dim, emitter=None,
                  feedback_brick=None, merge=None, merge_prototype=None,
                  post_merge=None, merged_dim=None, **kwargs):
@@ -449,7 +449,7 @@ class TrivialEmitter(AbstractEmitter):
     By default :meth:`cost` always returns zero tensor.
 
     """
-    @lazy
+    @lazy(allocation=['readout_dim'])
     def __init__(self, readout_dim, **kwargs):
         super(TrivialEmitter, self).__init__(**kwargs)
         self.readout_dim = readout_dim
@@ -526,7 +526,7 @@ class SoftmaxEmitter(AbstractEmitter, Initializable, Random):
 
 class TrivialFeedback(AbstractFeedback):
     """A feedback brick for the case when readout are outputs."""
-    @lazy
+    @lazy(allocation=['output_dim'])
     def __init__(self, output_dim, **kwargs):
         super(TrivialFeedback, self).__init__(**kwargs)
         self.output_dim = output_dim

--- a/docs/bricks_overview.rst
+++ b/docs/bricks_overview.rst
@@ -116,7 +116,7 @@ it fully (or at all):
 
     >>> linear2 = Linear(output_dim=10)
     >>> print(linear2.input_dim)
-    None
+    NoneAllocation
 
 Of course, as long as the brick is not configured, we cannot actually apply it!
 

--- a/docs/bricks_overview.rst
+++ b/docs/bricks_overview.rst
@@ -123,8 +123,7 @@ Of course, as long as the brick is not configured, we cannot actually apply it!
     >>> linear2.apply(x)
     Traceback (most recent call last):
       ...
-    TypeError: Lazy initialization is enabled, so please make sure you have set
-    all the required configuration for this method call.
+    ValueError: allocation config not set: input_dim
 
 We can now easily configure our brick based on other bricks.
 

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -53,7 +53,7 @@ class ParentBrick(Brick):
         super(ParentBrick, self).__init__(**kwargs)
         self.child = child
         if child is None:
-            child = TestBrick()
+            child = TestBrick(0)
         self.children = [child]
 
     @application
@@ -114,6 +114,8 @@ def test_repr():
 
 
 def test_lazy():
+    linear = Linear()
+    assert linear.allocation_args == ['input_dim', 'output_dim']
     brick = TestBrick()
     assert brick.config is NoneAllocation
     brick = TestBrick(config='config')
@@ -122,7 +124,7 @@ def test_lazy():
 
 
 def test_allocate():
-    brick = TestBrick()
+    brick = TestBrick(0)
     brick.allocate()
     assert brick.allocated
     assert brick.allocation_config_pushed
@@ -153,7 +155,7 @@ def test_allocate():
 
 
 def test_initialize():
-    brick = TestBrick()
+    brick = TestBrick(0)
     brick.initialize()
 
     parent_brick = ParentBrick()
@@ -167,7 +169,7 @@ def test_initialize():
 
 
 def test_tagging():
-    brick = TestBrick()
+    brick = TestBrick(0)
     x = tensor.vector('x')
     y = tensor.vector('y')
     z = tensor.vector('z')
@@ -248,7 +250,7 @@ def test_application():
 
 
 def test_apply():
-    brick = TestBrick()
+    brick = TestBrick(0)
     assert TestBrick.apply(brick, [0]) == [0, 1]
     if six.PY2:
         assert_raises(TypeError, TestBrick.apply, [0])
@@ -437,7 +439,7 @@ def test_sequence_variable_inputs():
 
 def test_application_call():
     X = tensor.matrix('X')
-    brick = TestBrick()
+    brick = TestBrick(0)
     Y = brick.access_application_call(X)
     (auxiliary_variable,) = get_application_call(Y).auxiliary_variables
     assert auxiliary_variable.name == 'test_val'

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -14,7 +14,7 @@ from blocks.utils import shared_floatx
 
 
 class TestBrick(Brick):
-    @lazy
+    @lazy(allocation=['config'])
     def __init__(self, config, **kwargs):
         super(TestBrick, self).__init__(**kwargs)
         self.config = config

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -6,7 +6,7 @@ from theano import tensor
 
 from blocks.bricks import (Identity, Linear, Maxout, LinearMaxout, MLP, Tanh,
                            Sequence, Random)
-from blocks.bricks.base import Application, application, Brick, lazy
+from blocks.bricks.base import application, Brick, lazy, NoneAllocation
 from blocks.bricks.parallel import Parallel, Fork
 from blocks.filter import get_application_call, get_brick
 from blocks.initialization import Constant
@@ -114,12 +114,8 @@ def test_repr():
 
 
 def test_lazy():
-    Brick.lazy = False
-    assert_raises(TypeError, TestBrick)
-    Brick.lazy = True
-
     brick = TestBrick()
-    assert brick.config is None
+    assert brick.config is NoneAllocation
     brick = TestBrick(config='config')
     assert brick.config == 'config'
     assert_raises(ValueError, TestBrick, 'config', config='config')
@@ -150,12 +146,10 @@ def test_allocate():
     assert not broken_parent_brick.allocation_config_pushed
     assert not broken_parent_brick.allocated
 
-    Brick.lazy = False
     broken_parent_brick = ParentBrick(BrokenAllocateBrick())
     assert_raises(AttributeError, broken_parent_brick.allocate)
     assert not broken_parent_brick.allocation_config_pushed
     assert not broken_parent_brick.allocated
-    Brick.lazy = True
 
 
 def test_initialize():
@@ -168,10 +162,8 @@ def test_initialize():
     broken_parent_brick = ParentBrick(BrokenInitializeBrick())
     assert_raises(AttributeError, broken_parent_brick.initialize)
 
-    Brick.lazy = False
     broken_parent_brick = ParentBrick(BrokenInitializeBrick())
     assert_raises(AttributeError, broken_parent_brick.initialize)
-    Brick.lazy = True
 
 
 def test_tagging():
@@ -253,15 +245,6 @@ def test_application():
     test_brick.delegated_apply.inputs = ['x']
     assert test_brick.delegated_apply.inputs == ['x']
     assert TestBrick.delegated_apply.inputs == ['w']
-
-    Brick.lazy = False
-    brick = TestBrick('config')
-    x = tensor.vector()
-    brick.apply(x)
-    assert brick.initialized
-
-    assert_raises(AttributeError, getattr, Application(lambda x: x), 'brick')
-    Brick.lazy = True
 
 
 def test_apply():

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -14,7 +14,7 @@ floatX = theano.config.floatX
 
 def test_application_graph_auxiliary_vars():
     X = tensor.matrix('X')
-    brick = TestBrick()
+    brick = TestBrick(0)
     Y = brick.access_application_call(X)
     graph = ComputationGraph(outputs=[Y])
     test_val_found = False

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -5,7 +5,6 @@ from theano import tensor
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 
 from blocks.bricks import MLP, Identity
-from blocks.bricks.base import Brick
 from blocks.graph import apply_noise, ComputationGraph
 from blocks.initialization import Constant
 from tests.bricks.test_bricks import TestBrick
@@ -15,7 +14,6 @@ floatX = theano.config.floatX
 
 def test_application_graph_auxiliary_vars():
     X = tensor.matrix('X')
-    Brick.lazy = True
     brick = TestBrick()
     Y = brick.access_application_call(X)
     graph = ComputationGraph(outputs=[Y])


### PR DESCRIPTION
@fvisin @rizar (and I believe @adbrebs touched on this in #384)

This is a stricter version of lazy initialization (spin-off of #528). The lazy decorator is now expected to say which values are needed at which stage of the brick life cycle. I also made laziness non-configurable, because of an important point that @fvisin brought up: It makes code annoying to port, because whether things work or not might depend on someone's configuration. I've also never seen someone explicitly set `Brick.lazy = False`.

```python
@lazy(allocation=['args', 'needed', 'for', 'allocation'],
      initialization=['likewise'])
def __init__(self, always_needed, args, needed, for allocation,
             likewise, allocation_var_with_default=None):
    pass
```

The main advantages:

* Arguments that are needed for brick construction are now actually compulsory again; in the current situation arguments needed in `__init__` would just be replaced with `None` and lead to weird errors.
* No more semi-allocated or semi-initialized bricks with cryptic errors in cases where the configuration wasn't set. We can now check in advance if needed configurations for allocation and initialization are missing.
* Simplification because users don't have to choose between lazy and non-lazy anymore. Bricks are just always lazy.