### PR TITLE
Detect MRG RNG variables

### DIFF
--- a/blocks/utils/__init__.py
+++ b/blocks/utils/__init__.py
@@ -292,11 +292,13 @@ def is_shared_variable(variable):
 
     Notes
     -----
-    This function excludes random shared variables.
+    This function excludes shared variables that store the state of Theano
+    random number generators.
 
     """
     return (isinstance(variable, SharedVariable) and
-            not isinstance(variable, RandomStateSharedVariable))
+            not isinstance(variable, RandomStateSharedVariable) and
+            not hasattr(variable, 'rng_owner'))
 
 
 def dict_subset(dict_, keys, pop=False, must_have=True):


### PR DESCRIPTION
Following https://github.com/Theano/Theano/pull/2670 we can now make sure that the state of MRG RNGs don't show up as shared variables. Strictly speaking the `hasattr` check should be enough, but I'll leave the `isinstance` one in there for people who haven't updated their Theano.