### PR TITLE
Switch to items instead of attributes for log entries

### DIFF
--- a/bin/blocks-plot
+++ b/bin/blocks-plot
@@ -46,9 +46,9 @@ def main(args):
     for fname in args.experiments:
         log = plot.load_log(fname)
 
-        rows_to_keep = ([0] + log.status._epoch_ends
+        rows_to_keep = ([0] + log.status['_epoch_ends']
                         if args.every == "epoch"
-                        else range(log.status.iterations_done))
+                        else range(log.status['iterations_done']))
         data_frame = log.to_dataframe()
         data_frame = data_frame.iloc[rows_to_keep]
 

--- a/blocks/extensions/monitoring.py
+++ b/blocks/extensions/monitoring.py
@@ -37,7 +37,7 @@ class MonitoringExtension(TrainingExtension):
         for name, value in record_tuples:
             if not name:
                 raise ValueError("monitor variable without name")
-            setattr(log.current_row, self._record_name(name), value)
+            log.current_row[self._record_name(name)] = value
 
 
 class DataStreamMonitoring(SimpleExtension, MonitoringExtension):
@@ -133,10 +133,10 @@ class TrainingDataMonitoring(SimpleExtension, MonitoringExtension):
                 self._buffer.accumulation_updates)
             self._buffer.initialize_aggregators()
         else:
-            if self.main_loop.status.iterations_done == self._last_time_called:
+            if self.main_loop.status['iterations_done'] == self._last_time_called:
                 raise Exception("TrainingDataMonitoring.do should be invoked"
                                 " no more than once per iteration")
-            self._last_time_called = self.main_loop.status.iterations_done
+            self._last_time_called = self.main_loop.status['iterations_done']
             self.add_records(self.main_loop.log,
                              self._buffer.get_aggregated_values().items())
             self._buffer.initialize_aggregators()

--- a/blocks/extensions/monitoring.py
+++ b/blocks/extensions/monitoring.py
@@ -133,7 +133,8 @@ class TrainingDataMonitoring(SimpleExtension, MonitoringExtension):
                 self._buffer.accumulation_updates)
             self._buffer.initialize_aggregators()
         else:
-            if self.main_loop.status['iterations_done'] == self._last_time_called:
+            if (self.main_loop.status['iterations_done'] ==
+                    self._last_time_called):
                 raise Exception("TrainingDataMonitoring.do should be invoked"
                                 " no more than once per iteration")
             self._last_time_called = self.main_loop.status['iterations_done']

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -102,7 +102,7 @@ class Plot(SimpleExtension):
 
     def do(self, which_callback, *args):
         log = self.main_loop.log
-        iteration = log.status.iterations_done
+        iteration = log.status['iterations_done']
         i = 0
         for key, value in log.current_row:
             if key in self.p_indices:

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -104,7 +104,7 @@ class Plot(SimpleExtension):
         log = self.main_loop.log
         iteration = log.status['iterations_done']
         i = 0
-        for key, value in log.current_row:
+        for key, value in log.current_row.items():
             if key in self.p_indices:
                 if key not in self.plots:
                     fig = self.p[self.p_indices[key]]

--- a/blocks/extensions/predicates.py
+++ b/blocks/extensions/predicates.py
@@ -11,4 +11,4 @@ class OnLogRecord(object):
         self.record_name = record_name
 
     def __call__(self, log):
-        return bool(log.current_row[self.record_name])
+        return bool(log.current_row.get(self.record_name, False))

--- a/blocks/extensions/saveload.py
+++ b/blocks/extensions/saveload.py
@@ -90,9 +90,7 @@ class Checkpoint(SimpleExtension):
             path = self.path
             if len(from_user):
                 path, = from_user
-            already_saved_to = self.main_loop.log.current_row[SAVED_TO]
-            if not already_saved_to:
-                already_saved_to = ()
+            already_saved_to = self.main_loop.log.current_row.get(SAVED_TO, ())
             self.main_loop.log.current_row[SAVED_TO] = (
                 already_saved_to + (path,))
             secure_pickle_dump(self.main_loop, path)

--- a/blocks/extensions/training.py
+++ b/blocks/extensions/training.py
@@ -36,7 +36,7 @@ class SharedVariableModifier(SimpleExtension):
         self.num_args = len(inspect.getargspec(function).args)
 
     def do(self, which_callback, *args):
-        iterations_done = self.main_loop.log.status.iterations_done
+        iterations_done = self.main_loop.log.status['iterations_done']
         if self.num_args == 1:
             new_value = self.function(iterations_done)
         else:
@@ -83,7 +83,7 @@ class TrackTheBest(SimpleExtension):
         current_value = self.main_loop.log.current_row[self.record_name]
         if current_value is None:
             return
-        best_value = getattr(self.main_loop.status, self.best_name, None)
+        best_value = self.main_loop.status.get(self.best_name, None)
         if (best_value is None or
                 (current_value != best_value and
                  self.choose_best(current_value, best_value) ==

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -1,9 +1,7 @@
 """The event-based main loop of Blocks."""
-from abc import ABCMeta
 from collections import defaultdict
 from numbers import Integral
 
-from six import add_metaclass
 try:
     from pandas import DataFrame
     PANDAS_AVAILABLE = True

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -1,6 +1,7 @@
 """The event-based main loop of Blocks."""
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 from collections import defaultdict
+from numbers import Integral
 
 from six import add_metaclass
 try:
@@ -10,265 +11,61 @@ except ImportError:
     PANDAS_AVAILABLE = False
 
 
-@add_metaclass(ABCMeta)
-class AbstractTrainingStatus(object):
-    """The base class for objects that carry the training status.
+class TrainingLog(defaultdict):
+    """Base class for training logs.
 
-    To support various backends (such as database tables) the
-    descendants of this class are expected to override the
-    `__getattr__`, `__setattr__`, `__hasattr__` methods.
+    A training log stores the training timeline, statistics and other
+    auxiliary information. Information is stored as a nested dictionary,
+    ``log[time][key]``. An entry without stored data will return an empty
+    dictionary (like ``defaultdict(dict)``).
+
+    In addition to the set of records displaying training dynamics, a
+    training log has a :attr:`status` attribute, which is a dictionary with
+    data that is not bound to a particular time.
 
     Attributes
     ----------
-    iterations_done : int
-        The number of iterations done.
-    epochs_done : int
-        The number of epochs done.
-    _epoch_ends : list
-        The numbers of the epochs last iterations.
-
-    .. todo::
-
-        We need some notion of an attributes property. Examples of possible
-        properties include a docstring, a priority level to be used by a
-        printing extension to decide whether a certain attribute should be
-        printed or not.
+    status : dict
+        A dictionary with data representing the current state of training.
+        By default it contains ``iterations_done``, ``epochs_done`` and
+        ``_epoch_ends`` (a list of time stamps when epochs ended).
 
     """
     def __init__(self):
-        self.iterations_done = 0
-        self.epochs_done = 0
-        self._epoch_ends = []
+        super(TrainingLog, self).__init__(dict)
+        self.status = {
+            'iterations_done': 0,
+            'epochs_done': 0,
+            '_epoch_ends': []
+        }
 
-    @abstractmethod
-    def __iter__(self):
-        """Return iterator through the status attributes.
-
-        The iterator should yield (attribute name, attribute value) pairs.
-
-        """
-        pass
-
-    def __getitem__(self, key):
-        return getattr(self, key)
-
-    def __setitem__(self, key, value):
-        return setattr(self, key, value)
-
-    def __contains__(self, key):
-        return hasattr(self, key)
-
-
-class TrainingLogRow(object):
-    """A convenience interface for a row of the training log.
-
-    Parameters
-    ----------
-    log : instance of :class:`AbstractTrainingLog`.
-        The log to which the row belongs.
-    time : int
-        A time step of the row.
-
-    """
-    def __init__(self, log, time):
-        self.log = log
-        self.time = time
-
-    def __getattr__(self, key):
-        return self.log.fetch_record(self.time, key)
-
-    def __getitem__(self, key):
-        return getattr(self, key)
-
-    def __setitem__(self, key, value):
-        setattr(self, key, value)
-
-    def __setattr__(self, key, value):
-        if key in ['log', 'time']:
-            return super(TrainingLogRow, self).__setattr__(key, value)
-        self.log.add_record(self.time, key, value)
-
-    def __iter__(self):
-        return self.log.get_row_iterator(self.time)
-
-
-@add_metaclass(ABCMeta)
-class AbstractTrainingLog(object):
-    """Base class for training logs.
-
-    A training log stores the training timeline, statistics and
-    other auxiliary information. Information is represented as a set of
-    time-key-value triples. A default value can be set for a key that
-    will be used when no other value is provided explicitly. The default
-    default value is ''None''.
-
-    In addition to the set of records displaying training dynamics, a
-    training log has a status object whose attributes form the state of
-
-    Another related concept is a row of the log, which is a set of record
-    sharing the same time component. The log interface has a few routines
-    to allow convenient access to the rows.
-
-    """
-    @abstractmethod
-    def get_status(self):
-        """Returns the training status.
-
-        Returns
-        -------
-            An instance of :class:`AbstractTrainingStatus`, whose
-            attributes contain the information regarding the status of
-            the training process.
-
-        """
-        pass
-
-    @property
-    def status(self):
-        """A convenient way to access the status."""
-        return self.get_status()
-
-    @abstractmethod
-    def set_default_value(self, key, value):
-        """Sets a default value for 'key'."""
-        pass
-
-    @abstractmethod
-    def get_default_value(self, key):
-        """Returns the default value set for the 'key'.
-
-        Returns
-        -------
-        The default value for the `key`, or ``None`` if not set.
-
-        """
-        pass
-
-    def add_record(self, time, key, value):
-        """Adds a record to the log.
-
-        If `value` equals to the default value for the `key`, nothing is
-        done.
-
-        """
-        self._check_time(time)
-        default_value = self.get_default_value(key)
-        if value != default_value:
-            self._add_record(time, key, value)
-
-    @abstractmethod
-    def _add_record(self, time, key, value):
-        """Adds a record to the log.
-
-        The implementation method to be overridden.
-
-        """
-        pass
-
-    def fetch_record(self, time, key):
-        """Fetches a record from the log.
-
-        If no such 'key' for the `time` is found or if the value for the
-        key is ``None``, the default value for the 'key' is returned.
-
-        """
-        self._check_time(time)
-        value = self._fetch_record(time, key)
-        if value is not None:
-            return value
-        return self.get_default_value(key)
-
-    @abstractmethod
-    def _fetch_record(self, time, key):
-        """Fetches a record from the log.
-
-        The implementation method to be overridden.
-
-        """
-        pass
+    def __reduce__(self):
+        constructor, args, _, _, items = super(TrainingLog, self).__reduce__()
+        return constructor, (), self.__dict__, _, items
 
     def __getitem__(self, time):
         self._check_time(time)
-        return TrainingLogRow(self, time)
+        return super(TrainingLog, self).__getitem__(time)
+
+    def _check_time(self, time):
+        if not isinstance(time, Integral) or time < 0:
+            raise ValueError("time must be a positive integer")
 
     @property
     def current_row(self):
-        return self[self.status.iterations_done]
+        return self[self.status['iterations_done']]
 
     @property
     def previous_row(self):
-        return self[self.status.iterations_done - 1]
+        return self[self.status['iterations_done'] - 1]
 
     @property
     def last_epoch_row(self):
-        return self[self.status._epoch_ends[-1]]
-
-    @abstractmethod
-    def __iter__(self):
-        """Returns an iterator over time-key-value triples of the log."""
-        pass
-
-    @abstractmethod
-    def get_row_iterator(self, time):
-        """Returns an iterator over key-value pairs of a row of the log."""
-        pass
-
-    def _check_time(self, time):
-        if not isinstance(time, int) or time < 0:
-            raise ValueError("time must be a positive integer")
+        return self[self.status['_epoch_ends'][-1]]
 
     def to_dataframe(self):
         """Convert a log into a :class:`.DataFrame`."""
         if not PANDAS_AVAILABLE:
             raise ImportError("The pandas library is not found. You can"
                               " install it with pip.")
-        return self._to_dataframe()
-
-    def _to_dataframe(self):
-        raise NotImplementedError()
-
-
-class TrainingStatus(AbstractTrainingStatus):
-    """A simple training status."""
-    def __iter__(self):
-        for attr, value in self.__dict__.items():
-            if not attr.startswith("__"):
-                yield attr, value
-
-
-class TrainingLog(AbstractTrainingLog):
-    """A simple training log storing information in main memory."""
-    def __init__(self):
-        self._storage = defaultdict(dict)
-        self._default_values = {}
-        self._status = TrainingStatus()
-
-    def get_default_value(self, key):
-        return self._default_values.get(key)
-
-    def set_default_value(self, key, value):
-        self._default_values[key] = value
-
-    def _add_record(self, time, key, value):
-        self._storage[time][key] = value
-
-    def _fetch_record(self, time, key):
-        slice_ = self._storage.get(time)
-        if not slice_:
-            return None
-        return slice_.get(key)
-
-    def get_row_iterator(self, time):
-        for key, value in self._storage[time].items():
-            yield key, value
-
-    def __iter__(self):
-        for time, records in self._storage.items():
-            for key, value in records.items():
-                yield time, key, value
-
-    def get_status(self):
-        return self._status
-
-    def _to_dataframe(self):
-        return DataFrame.from_dict(self._storage, orient='index')
+        return DataFrame.from_dict(self, orient='index')

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -96,10 +96,10 @@ class MainLoop(object):
 
         self._model = model
 
-        self.status._training_started = False
-        self.status._epoch_started = False
-        self.status._epoch_interrupt_received = False
-        self.status._batch_interrupt_received = False
+        self.status['training_started'] = False
+        self.status['epoch_started'] = False
+        self.status['epoch_interrupt_received'] = False
+        self.status['batch_interrupt_received'] = False
 
     @property
     def model(self):
@@ -150,26 +150,26 @@ class MainLoop(object):
                 signal.SIGTERM, self._handle_batch_interrupt)
             try:
                 logger.info("Entered the main loop")
-                if not self.status._training_started:
+                if not self.status['training_started']:
                     for extension in self.extensions:
                         extension.main_loop = self
                     self._run_extensions('before_training')
                     self.algorithm.initialize()
-                    self.status._training_started = True
+                    self.status['training_started'] = True
                 # We can not write "else:" here because extensions
                 # called "before_training" could have changed the status
                 # of the main loop.
-                if self.log.status.iterations_done > 0:
+                if self.log.status['iterations_done'] > 0:
                     self._run_extensions('on_resumption')
-                    self.status._epoch_interrupt_received = False
-                    self.status._batch_interrupt_received = False
+                    self.status['epoch_interrupt_received'] = False
+                    self.status['batch_interrupt_received'] = False
                 while self._run_epoch():
                     pass
             except TrainingFinish:
-                self.log.current_row.training_finished = True
+                self.log.current_row['training_finished'] = True
             except Exception as e:
                 self._restore_signal_handlers()
-                self.log.current_row.got_exception = traceback.format_exc(e)
+                self.log.current_row['got_exception'] = traceback.format_exc(e)
                 logger.error("Error occured during training." + error_message)
                 try:
                     self._run_extensions('on_error')
@@ -179,7 +179,7 @@ class MainLoop(object):
                                  error_in_error_handling_message)
                 reraise_as(e)
             finally:
-                if self.log.current_row.training_finished:
+                if self.log.current_row.get('training_finished', False):
                     self._run_extensions('after_training')
                 self._restore_signal_handlers()
 
@@ -200,20 +200,20 @@ class MainLoop(object):
                        if extension.name == name], singleton=True)
 
     def _run_epoch(self):
-        if not self.status._epoch_started:
+        if not self.status.get('epoch_started', False):
             try:
-                self.log.status._received_first_batch = False
+                self.log.status['received_first_batch'] = False
                 self.epoch_iterator = (self.data_stream.
                                        get_epoch_iterator(as_dict=True))
             except StopIteration:
                 return False
-            self.status._epoch_started = True
+            self.status['epoch_started'] = True
             self._run_extensions('before_epoch')
         while self._run_iteration():
             pass
-        self.status._epoch_started = False
-        self.status.epochs_done += 1
-        self.status._epoch_ends.append(self.status.iterations_done)
+        self.status['epoch_started'] = False
+        self.status['epochs_done'] += 1
+        self.status['_epoch_ends'].append(self.status['iterations_done'])
         self._run_extensions('after_epoch')
         self._check_finish_training('epoch')
         return True
@@ -222,13 +222,13 @@ class MainLoop(object):
         try:
             batch = next(self.epoch_iterator)
         except StopIteration:
-            if not self.log.status._received_first_batch:
+            if not self.log.status['received_first_batch']:
                 reraise_as(ValueError("epoch iterator yielded zero batches"))
             return False
-        self.log.status._received_first_batch = True
+        self.log.status['received_first_batch'] = True
         self._run_extensions('before_batch', batch)
         self.algorithm.process_batch(batch)
-        self.status.iterations_done += 1
+        self.status['iterations_done'] += 1
         self._run_extensions('after_batch', batch)
         self._check_finish_training('batch')
         return True
@@ -250,11 +250,11 @@ class MainLoop(object):
         # In case when keyboard interrupt is handled right at the end of
         # the iteration the corresponding log record can be found only in
         # the previous row.
-        if (self.log.current_row.training_finish_requested or
-                self.status._batch_interrupt_received):
+        if (self.log.current_row.get('training_finish_requested', False) or
+                self.status.get('batch_interrupt_received', False)):
             raise TrainingFinish
         if (level == 'epoch' and
-                self.status._epoch_interrupt_received):
+                self.status.get('epoch_interrupt_received', False)):
             raise TrainingFinish
 
     def _handle_epoch_interrupt(self, signal_number, frame):
@@ -262,20 +262,20 @@ class MainLoop(object):
         logger.warning('Received epoch interrupt signal.' +
                        epoch_interrupt_message)
         signal.signal(signal.SIGINT, self._handle_batch_interrupt)
-        self.log.current_row.epoch_interrupt_received = True
+        self.log.current_row['epoch_interrupt_received'] = True
         # Add a record to the status. Unlike the log record it will be
         # easy to access at later iterations.
-        self.status._epoch_interrupt_received = True
+        self.status['epoch_interrupt_received'] = True
 
     def _handle_batch_interrupt(self, signal_number, frame):
         # After 2nd CTRL + C or SIGTERM signal (from cluster) finish batch
         self._restore_signal_handlers()
         logger.warning('Received batch interrupt signal.' +
                        batch_interrupt_message)
-        self.log.current_row.batch_interrupt_received = True
+        self.log.current_row['batch_interrupt_received'] = True
         # Add a record to the status. Unlike the log record it will be
         # easy to access at later iterations.
-        self.status._batch_interrupt_received = True
+        self.status['batch_interrupt_received'] = True
 
     def _restore_signal_handlers(self):
         signal.signal(signal.SIGINT, self.original_sigint_handler)

--- a/blocks/scripts/plot.py
+++ b/blocks/scripts/plot.py
@@ -10,7 +10,7 @@ from functools import reduce
 
 from blocks import config
 from blocks.utils import change_recursion_limit
-from blocks.log import AbstractTrainingLog
+from blocks.log import TrainingLog
 from blocks.main_loop import MainLoop
 
 try:
@@ -24,7 +24,7 @@ def load_log(fname):
     """Load a :claas:`TrainingLog` object from disk.
 
     This function automatically handles various file formats that contain
-    an instance of an :claas:`AbstractTrainingLog`. This includes a pickled
+    an instance of an :claas:`TrainingLog`. This includes a pickled
     Log object, a pickled :claas:`MainLoop` or an experiment dump (TODO).
 
     """
@@ -33,7 +33,7 @@ def load_log(fname):
             from_disk = cPickle.load(f)
         # TODO: Load "dumped" experiments
 
-    if isinstance(from_disk, AbstractTrainingLog):
+    if isinstance(from_disk, TrainingLog):
         log = from_disk
     elif isinstance(from_disk, MainLoop):
         log = from_disk.log

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -82,7 +82,7 @@ def _filter_long(data):
 
 
 def _is_nan(log):
-    return math.isnan(log.current_row.total_gradient_norm)
+    return math.isnan(log.current_row['total_gradient_norm'])
 
 
 class WordReverser(Initializable):

--- a/tests/extensions/test_monitoring.py
+++ b/tests/extensions/test_monitoring.py
@@ -33,7 +33,7 @@ def test_training_data_monitoring():
     class TrueCostExtension(TrainingExtension):
 
         def before_batch(self, data):
-            self.main_loop.log.current_row.true_cost = (
+            self.main_loop.log.current_row['true_cost'] = (
                 ((W.get_value() * data["features"]).sum() -
                  data["targets"]) ** 2)
 
@@ -52,19 +52,19 @@ def test_training_data_monitoring():
     main_loop.run()
 
     # Check monitoring of a shared varible
-    assert_allclose(main_loop.log.current_row.train1_V, 7.0)
+    assert_allclose(main_loop.log.current_row['train1_V'], 7.0)
 
     for i in range(n_batches):
         # The ground truth is written to the log before the batch is
         # processed, where as the extension writes after the batch is
         # processed. This is why the iteration numbers differs here.
-        assert_allclose(main_loop.log[i].true_cost,
-                        main_loop.log[i + 1].train1_cost)
+        assert_allclose(main_loop.log[i]['true_cost'],
+                        main_loop.log[i + 1]['train1_cost'])
     assert_allclose(
-        main_loop.log[n_batches].train2_cost,
-        sum([main_loop.log[i].true_cost
+        main_loop.log[n_batches]['train2_cost'],
+        sum([main_loop.log[i]['true_cost']
              for i in range(n_batches)]) / n_batches)
     assert_allclose(
-        main_loop.log[n_batches].train2_W_sum,
-        sum([main_loop.log[i].train1_W_sum
+        main_loop.log[n_batches]['train2_W_sum'],
+        sum([main_loop.log[i]['train1_W_sum']
              for i in range(1, n_batches + 1)]) / n_batches)

--- a/tests/extensions/test_timing.py
+++ b/tests/extensions/test_timing.py
@@ -16,33 +16,33 @@ def test_timing():
     # Start epoch 1
     now += 2
     timing.before_epoch()
-    assert ml.log[0].initialization_took == 2
-    ml.log.status._epoch_started = True
+    assert ml.log[0]['initialization_took'] == 2
+    ml.log.status['epoch_started'] = True
 
     # Batch 1
     timing.before_batch(None)
     now += 7
-    ml.log.status.iterations_done += 1
+    ml.log.status['iterations_done'] += 1
     timing.after_batch(None)
-    assert ml.log[1].iteration_took == 7
+    assert ml.log[1]['iteration_took'] == 7
 
     # Batch 2
     timing.before_batch(None)
     now += 8
-    ml.log.status.iterations_done += 1
+    ml.log.status['iterations_done'] += 1
     timing.after_batch(None)
-    assert ml.log[2].iteration_took == 8
+    assert ml.log[2]['iteration_took'] == 8
 
     # Epoch 1 is done
-    ml.log.status.epochs_done += 1
+    ml.log.status['epochs_done'] += 1
     timing.after_epoch()
-    assert ml.log[2].epoch_took == 15
-    assert ml.log[2].total_took == 17
+    assert ml.log[2]['epoch_took'] == 15
+    assert ml.log[2]['total_took'] == 17
 
     # Finish training
     now += 1
     timing.after_training()
-    assert ml.log[2].final_total_took == 18
+    assert ml.log[2]['final_total_took'] == 18
 
     # Resume training
     now = 0
@@ -50,15 +50,15 @@ def test_timing():
 
     # Start epoch 2
     timing.before_epoch()
-    assert ml.log[2].initialization_took is None
+    assert ml.log[2].get('initialization_took', None) is None
 
     # Batch 3
     timing.before_batch(None)
     now += 6
-    ml.log.status.iterations_done += 1
+    ml.log.status['iterations_done'] += 1
     timing.after_batch(None)
-    assert ml.log[3].iteration_took == 6
-    assert ml.log[3].total_took == 24
+    assert ml.log[3]['iteration_took'] == 6
+    assert ml.log[3]['total_took'] == 24
 
     # Finish training before the end of the current epoch
     timing.after_training()
@@ -70,15 +70,15 @@ def test_timing():
     # Batch 4
     timing.before_batch(None)
     now += 2
-    ml.log.status.iterations_done += 1
+    ml.log.status['iterations_done'] += 1
     timing.after_batch(None)
-    assert ml.log[4].iteration_took == 2
-    assert ml.log[4].total_took == 26
+    assert ml.log[4]['iteration_took'] == 2
+    assert ml.log[4]['total_took'] == 26
 
     # Epoch 2 is done
-    ml.log.status.epochs_done += 1
+    ml.log.status['epochs_done'] += 1
     timing.after_epoch()
-    assert ml.log[4].epoch_took == 8
+    assert ml.log[4]['epoch_took'] == 8
 
     # Start epoch 3
     timing.before_epoch()
@@ -86,12 +86,12 @@ def test_timing():
     # Batch 5
     timing.before_batch(None)
     now += 5
-    ml.log.status.iterations_done += 1
+    ml.log.status['iterations_done'] += 1
     timing.after_batch(None)
-    assert ml.log[5].iteration_took == 5
-    assert ml.log[5].total_took == 31
+    assert ml.log[5]['iteration_took'] == 5
+    assert ml.log[5]['total_took'] == 31
 
     # Epoch 3 is done
-    ml.log.status.epochs_done += 1
+    ml.log.status['epochs_done'] += 1
     timing.after_epoch()
-    assert ml.log[5].epoch_took == 5
+    assert ml.log[5]['epoch_took'] == 5

--- a/tests/extensions/test_training.py
+++ b/tests/extensions/test_training.py
@@ -91,36 +91,36 @@ def test_track_the_best():
     extension = TrackTheBest("cost")
     extension.main_loop = main_loop
 
-    main_loop.status.iterations_done += 1
-    main_loop.log.current_row.cost = 5
+    main_loop.status['iterations_done'] += 1
+    main_loop.log.current_row['cost'] = 5
     extension.dispatch('after_batch')
-    assert main_loop.status.best_cost == 5
+    assert main_loop.status['best_cost'] == 5
     assert main_loop.log.current_row['cost_best_so_far']
 
-    main_loop.status.iterations_done += 1
-    main_loop.log.current_row.cost = 6
+    main_loop.status['iterations_done'] += 1
+    main_loop.log.current_row['cost'] = 6
     extension.dispatch('after_batch')
-    assert main_loop.status.best_cost == 5
-    assert main_loop.log.current_row['cost_best_so_far'] is None
+    assert main_loop.status['best_cost'] == 5
+    assert main_loop.log.current_row.get('cost_best_so_far', None) is None
 
-    main_loop.status.iterations_done += 1
-    main_loop.log.current_row.cost = 5
+    main_loop.status['iterations_done'] += 1
+    main_loop.log.current_row['cost'] = 5
     extension.dispatch('after_batch')
-    assert main_loop.status.best_cost == 5
-    assert main_loop.log.current_row['cost_best_so_far'] is None
+    assert main_loop.status['best_cost'] == 5
+    assert main_loop.log.current_row.get('cost_best_so_far', None) is None
 
-    main_loop.status.iterations_done += 1
-    main_loop.log.current_row.cost = 4
+    main_loop.status['iterations_done'] += 1
+    main_loop.log.current_row['cost'] = 4
     extension.dispatch('after_batch')
-    assert main_loop.status.best_cost == 4
+    assert main_loop.status['best_cost'] == 4
     assert main_loop.log.current_row['cost_best_so_far']
 
 
 class WriteCostExtension(TrainingExtension):
 
     def after_batch(self, batch):
-        self.main_loop.log.current_row.cost = abs(
-            self.main_loop.log.status.iterations_done - 5) + 3
+        self.main_loop.log.current_row['cost'] = abs(
+            self.main_loop.log.status['iterations_done'] - 5) + 3
 
 
 def test_save_the_best():
@@ -139,12 +139,12 @@ def test_save_the_best():
                             (dst_best.name,))])
         main_loop.run()
 
-        assert main_loop.log[4].saved_to == (dst.name, dst_best.name)
-        assert main_loop.log[5].saved_to == (dst.name, dst_best.name)
-        assert main_loop.log[6].saved_to == (dst.name,)
+        assert main_loop.log[4]['saved_to'] == (dst.name, dst_best.name)
+        assert main_loop.log[5]['saved_to'] == (dst.name, dst_best.name)
+        assert main_loop.log[6]['saved_to'] == (dst.name,)
         with open(dst_best.name, 'rb') as src:
-            assert cPickle.load(src).log.status.iterations_done == 5
+            assert cPickle.load(src).log.status['iterations_done'] == 5
         root, ext = os.path.splitext(dst_best.name)
         log_path = root + "_log" + ext
         with open(log_path, 'rb') as src:
-            assert cPickle.load(src).status.iterations_done == 5
+            assert cPickle.load(src).status['iterations_done'] == 5

--- a/tests/scripts/test_plot.py
+++ b/tests/scripts/test_plot.py
@@ -30,7 +30,7 @@ def some_experiments():
 
 def test_load_log():
     log = TrainingLog()
-    log[0].channel0 = 0
+    log[0]['channel0'] = 0
 
     # test simple TrainingLog pickles
     with tempfile.NamedTemporaryFile() as f:
@@ -38,7 +38,7 @@ def test_load_log():
         f.flush()
 
         log2 = plot.load_log(f.name)
-        assert log2[0].channel0 == 0
+        assert log2[0]['channel0'] == 0
 
     # test MainLoop pickles
     main_loop = MainLoop(model=None, data_stream=None,
@@ -49,7 +49,7 @@ def test_load_log():
         f.flush()
 
         log2 = plot.load_log(f.name)
-        assert log2[0].channel0 == 0
+        assert log2[0]['channel0'] == 0
 
 
 @silence_printing

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -50,8 +50,8 @@ def test_main_loop_dump_manager():
     folder2 = tempfile.mkdtemp()
 
     main_loop1 = sqrt_example(folder, 17)
-    assert main_loop1.log.status.epochs_done == 3
-    assert main_loop1.log.status.iterations_done == 17
+    assert main_loop1.log.status['epochs_done'] == 3
+    assert main_loop1.log.status['iterations_done'] == 17
 
     # Test loading from the folder where `main_loop` is saved
     main_loop2 = sqrt_example(folder2, 1)
@@ -65,9 +65,9 @@ def test_main_loop_dump_manager():
     # Continue until 33 iterations are done
     main_loop2.find_extension("FinishAfter").set_conditions(after_n_batches=33)
     main_loop2.run()
-    assert main_loop2.log.status.iterations_done == 33
+    assert main_loop2.log.status['iterations_done'] == 33
 
     # Compare with a main loop after continuous 33 iterations
     main_loop3 = sqrt_example(folder, 33)
-    assert main_loop3.log.status.iterations_done == 33
+    assert main_loop3.log.status['iterations_done'] == 33
     assert_equal(main_loop2, main_loop3, check_log=False)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,7 +30,7 @@ def test_mnist():
         main_loop.find_extension("FinishAfter").set_conditions(
             after_n_epochs=2)
         main_loop.run()
-        assert main_loop.log.status.epochs_done == 2
+        assert main_loop.log.status['epochs_done'] == 2
 
 
 @silence_printing

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -5,23 +5,13 @@ def test_training_log():
     log = TrainingLog()
 
     # test basic writing capabilities
-    log[0].field = 45
-    assert log[0].field == 45
-    assert log[1].field is None
-    assert log.current_row.field == 45
-    log.status.iterations_done += 1
-    assert log.status.iterations_done == 1
-    assert log.previous_row.field == 45
-
-    # test default values mechanism
-    log.set_default_value('flag', True)
-    assert log[0].flag
-    log[1].flag = False
-    assert not log[1].flag
+    log[0]['field'] = 45
+    assert log[0]['field'] == 45
+    assert log[1] == {}
+    assert log.current_row['field'] == 45
+    log.status['iterations_done'] += 1
+    assert log.status['iterations_done'] == 1
+    assert log.previous_row['field'] == 45
 
     # test iteration
     assert len(list(log)) == 2
-    df = log.to_dataframe()
-    assert list(sorted(df.columns)) == ["field", "flag"]
-    assert df.flag[1] is False
-    assert df.field[0] == 45

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -10,7 +10,8 @@ from tests import MockAlgorithm
 class WriteBatchExtension(TrainingExtension):
     """Writes data saved by MockAlgorithm to the log."""
     def after_batch(self, _):
-        self.main_loop.log.current_row['batch'] = self.main_loop.algorithm.batch
+        self.main_loop.log.current_row['batch'] = \
+            self.main_loop.algorithm.batch
 
 
 def test_main_loop():

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -10,7 +10,7 @@ from tests import MockAlgorithm
 class WriteBatchExtension(TrainingExtension):
     """Writes data saved by MockAlgorithm to the log."""
     def after_batch(self, _):
-        self.main_loop.log.current_row.batch = self.main_loop.algorithm.batch
+        self.main_loop.log.current_row['batch'] = self.main_loop.algorithm.batch
 
 
 def test_main_loop():
@@ -34,17 +34,17 @@ def test_main_loop():
 
     finish_extension = FinishAfter()
     finish_extension.add_condition(
-        'after_epoch', predicate=lambda log: log.status.epochs_done == 2)
+        'after_epoch', predicate=lambda log: log.status['epochs_done'] == 2)
     main_loop = MainLoop(MockAlgorithm(), TestDataStream(),
                          extensions=[WriteBatchExtension(),
                                      finish_extension])
     main_loop.run()
 
-    assert main_loop.log.status.iterations_done == 5
-    assert main_loop.log.status._epoch_ends == [3, 5]
-    assert len(list(main_loop.log)) == 7
+    assert main_loop.log.status['iterations_done'] == 5
+    assert main_loop.log.status['_epoch_ends'] == [3, 5]
+    assert len(main_loop.log) == 5
     for i in range(1, 6):
-        assert main_loop.log[i].batch == dict(data=i)
+        assert main_loop.log[i]['batch'] == dict(data=i)
 
 
 def test_training_resumption():
@@ -55,7 +55,7 @@ def test_training_resumption():
             extensions=[WriteBatchExtension(),
                         FinishAfter(after_n_batches=14)])
         main_loop.run()
-        assert main_loop.log.status.iterations_done == 14
+        assert main_loop.log.status['iterations_done'] == 14
 
         if with_serialization:
             main_loop = cPickle.loads(cPickle.dumps(main_loop))
@@ -65,12 +65,12 @@ def test_training_resumption():
              if isinstance(ext, FinishAfter)], singleton=True)
         finish_after.add_condition(
             "after_batch",
-            predicate=lambda log: log.status.iterations_done == 27)
+            predicate=lambda log: log.status['iterations_done'] == 27)
         main_loop.run()
-        assert main_loop.log.status.iterations_done == 27
-        assert main_loop.log.status.epochs_done == 2
+        assert main_loop.log.status['iterations_done'] == 27
+        assert main_loop.log.status['epochs_done'] == 2
         for i in range(27):
-            assert main_loop.log[i + 1].batch == {"data": i % 10}
+            assert main_loop.log[i + 1]['batch'] == {"data": i % 10}
 
     do_test(False)
     do_test(True)


### PR DESCRIPTION
Spin-off of #476 (and an attempt to make that PR a bit less humongous). This switches from using attributes (`log[0].cost`) for log items to keys (`log[0]['cost']`), which I personally think is more standard; keys seem to be more apt for very mutable data. It also allows us to simply subclass `defaultdict` instead of having a large number of custom methods.

I also removed the functionality of setting defaults, which wasn't used anywhere, and significantly simplified the logging interface and classes. The interface is now simply:

* `log` behaves as a `defaultdict`, accepting `i > 0` keys and returning a `dict` as a result.
* `log[i]` is a dictionary
* `log.status` is a dictionary