### PR TITLE
Made ProgressBar work when no scheme

### DIFF
--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -444,7 +444,12 @@ class ProgressBar(TrainingExtension):
 
     def get_iter_per_epoch(self):
         """Try to infer the number of iterations per epoch."""
-        iter_scheme = self.main_loop.data_stream.iteration_scheme
+        data_stream = self.main_loop.data_stream
+        while (not hasattr(data_stream.iteration_scheme, 'num_batches') and
+               not hasattr(data_stream.iteration_scheme, 'num_examples') and
+               hasattr(data_stream, 'data_stream')):
+            data_stream = data_stream.data_stream
+        iter_scheme = data_stream.iteration_scheme
         if hasattr(iter_scheme, 'num_batches'):
             return iter_scheme.num_batches
         elif (hasattr(iter_scheme, 'num_examples') and

--- a/tests/extensions/test_progressbar.py
+++ b/tests/extensions/test_progressbar.py
@@ -1,6 +1,7 @@
 import numpy
 import theano
 from fuel.datasets import IterableDataset
+from fuel.transformers import Mapping
 from theano import tensor
 
 from blocks.algorithms import GradientDescent, Scale
@@ -11,7 +12,11 @@ from blocks.utils import shared_floatx
 floatX = theano.config.floatX
 
 
-def setup_mainloop(extension):
+def times_two(x):
+    return x[0] * 2,
+
+
+def setup_mainloop(extension, transformer=False):
     """Set up a simple main loop for progress bar tests.
 
     Create a MainLoop, register the given extension, supply it with a
@@ -21,6 +26,10 @@ def setup_mainloop(extension):
     features = [numpy.array(f, dtype=floatX)
                 for f in [[1, 2], [3, 4], [5, 6]]]
     dataset = IterableDataset(dict(features=features))
+    if transformer:
+        data_stream = Mapping(dataset.get_example_stream(), times_two)
+    else:
+        data_stream = dataset.get_example_stream()
 
     W = shared_floatx([0, 0], name='W')
     x = tensor.vector('features')
@@ -31,7 +40,7 @@ def setup_mainloop(extension):
                                 step_rule=Scale(1e-3))
 
     main_loop = MainLoop(
-        model=None, data_stream=dataset.get_example_stream(),
+        model=None, data_stream=data_stream,
         algorithm=algorithm,
         extensions=[
             FinishAfter(after_n_epochs=1),
@@ -42,6 +51,13 @@ def setup_mainloop(extension):
 
 def test_progressbar():
     main_loop = setup_mainloop(ProgressBar())
+
+    # We are happy if it does not crash or raise any exceptions
+    main_loop.run()
+
+
+def test_progressbar_transformer():
+    main_loop = setup_mainloop(ProgressBar(), True)
 
     # We are happy if it does not crash or raise any exceptions
     main_loop.run()


### PR DESCRIPTION
ProgressBar now works when the top data stream doesn't have an iteration scheme. It searches parent streams with `num_batches` or `num_examples` attribute. I suppose, that it is legitimate because usually a transformer without an iteration scheme doesn't influence these attributes.