### PR TITLE
Add missing documentation and minor typos fix

### DIFF
--- a/blocks/dump.py
+++ b/blocks/dump.py
@@ -49,7 +49,7 @@ def save_parameter_values(param_values, path):
 
 
 def load_parameter_values(path):
-    """Load parameter values saved by :fun:`save_parameters`.
+    """Load parameter values saved by :func:`save_parameters`.
 
     This is a thin wrapper over `numpy.load`. It deals with
     `numpy`'s vulnerability to slashes in file names.

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -36,8 +36,8 @@ class AbstractModel(object):
     The following are traits of every model:
 
     * It has parameters and supports a way to access them. In addition
-    to returning handles to parameter objects it can return their values
-    as numpy arrays and set their values to given numpy arrays.
+      to returning handles to parameter objects it can return their values
+      as numpy arrays and set their values to given numpy arrays.
 
     * It has an optimality objective.
 

--- a/blocks/monitoring/aggregation.py
+++ b/blocks/monitoring/aggregation.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class AggregationScheme(object):
     """How to incrementally evaluate a Theano variable over minibatches.
 
-    An AggregationScheme allocates :class:`Aggregator`s that can
+    An AggregationScheme allocates :class:`Aggregator` that can
     incrementally compute the value of a Theano variable on a full dataset
     by aggregating partial results computed on multiple batches.
 
@@ -157,16 +157,11 @@ class TakeLast(AggregationScheme):
 class MonitoredQuantity(object):
     """The base class for monitored-quantities.
 
-    To monitor a non-Theano quanity in Blocks you have to implement this
+    To monitor a non-Theano quantity in Blocks you have to implement this
     interface for it. The initialize method initializes accumulators and
     the parameters needed to compute this quantity, accumulate method
-    accumulates results for every batch, and finallly readout is called
-    to get the accumulated resutls.
-
-    See Also
-    ------------
-    :class:`~blocks.monitoring.evaluators.DatasetEvaluator`
-    :class:`~blocks.extensions.DataStreamMonitoring`
+    accumulates results for every batch, and finally readout is called
+    to get the accumulated results.
 
     Attributes
     ----------
@@ -174,6 +169,11 @@ class MonitoredQuantity(object):
         List of Theano variables needed to calculate this quantity.
     name : str
         The name of monitored quantity which appears in the log.
+
+    See Also
+    --------
+    :class:`~blocks.monitoring.evaluators.DatasetEvaluator`
+    :class:`~blocks.extensions.DataStreamMonitoring`
 
     """
     def __init__(self, requires=None, name=None):

--- a/blocks/scripts/plot.py
+++ b/blocks/scripts/plot.py
@@ -21,11 +21,11 @@ except ImportError:
 
 
 def load_log(fname):
-    """Load a :claas:`TrainingLog` object from disk.
+    """Load a :class:`TrainingLog` object from disk.
 
     This function automatically handles various file formats that contain
-    an instance of an :claas:`TrainingLog`. This includes a pickled
-    Log object, a pickled :claas:`MainLoop` or an experiment dump (TODO).
+    an instance of an :class:`TrainingLog`. This includes a pickled
+    Log object, a pickled :class:`MainLoop` or an experiment dump (TODO).
 
     """
     with change_recursion_limit(config.recursion_limit):

--- a/docs/api/bricks.rst
+++ b/docs/api/bricks.rst
@@ -67,3 +67,10 @@ Cost bricks
     :members:
     :undoc-members:
     :show-inheritance:
+
+Wrapper bricks
+--------------
+.. automodule:: blocks.bricks.wrappers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/extensions.rst
+++ b/docs/api/extensions.rst
@@ -19,6 +19,14 @@ Monitoring extensions
     :undoc-members:
     :show-inheritance:
 
+Training
+--------
+
+.. automodule:: blocks.extensions.training
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Serialization
 -------------
 

--- a/docs/api/filter.rst
+++ b/docs/api/filter.rst
@@ -1,0 +1,9 @@
+.. _filter:
+
+Filter
+======
+
+.. automodule:: blocks.filter
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/model.rst
+++ b/docs/api/model.rst
@@ -1,0 +1,7 @@
+Model
+=====
+
+.. automodule:: blocks.model
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/scripts.rst
+++ b/docs/api/scripts.rst
@@ -1,0 +1,7 @@
+Plot
+====
+
+.. automodule:: blocks.scripts.plot
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/theano_expressions.rst
+++ b/docs/api/theano_expressions.rst
@@ -1,0 +1,9 @@
+.. _theano_expressions:
+
+Theano expressions
+==================
+
+.. automodule:: blocks.theano_expressions
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/bricks_overview.rst
+++ b/docs/bricks_overview.rst
@@ -40,8 +40,8 @@ The life-cycle of a brick is as follows:
 
 .. note::
    If the Theano variables of the brick object have not been allocated when 
-      :meth:`~.Application.apply` is called, Blocks will quietly call 
-         :meth:`.Brick.allocate`.
+   :meth:`~.Application.apply` is called, Blocks will quietly call 
+   :meth:`.Brick.allocate`.
 
 Example
 ^^^^^^^

--- a/docs/development/internal_api.rst
+++ b/docs/development/internal_api.rst
@@ -1,6 +1,12 @@
 Internal API
 ============
 
+* `Bricks`_
+* `Extensions`_
+* `Utils`_
+
+Bricks
+------
 .. automodule:: blocks.bricks.base
    :undoc-members:
    :members:
@@ -10,5 +16,45 @@ Internal API
 .. automodule:: blocks.bricks
    :members: Activation, ActivationDocumentation
    :undoc-members:
+   :private-members:
+   :show-inheritance:
+
+Extensions
+----------
+.. automodule:: blocks.extensions.predicates
+   :undoc-members:
+   :members:
+   :private-members:
+   :show-inheritance:
+
+.. automodule:: blocks.monitoring.evaluators
+   :undoc-members:
+   :members:
+   :private-members:
+   :show-inheritance:
+
+Utils
+-----
+.. automodule:: blocks.utils.containers
+   :undoc-members:
+   :members:
+   :private-members:
+   :show-inheritance:
+
+.. automodule:: blocks.dump
+   :undoc-members:
+   :members:
+   :private-members:
+   :show-inheritance:
+
+.. automodule:: blocks.utils.profile
+   :undoc-members:
+   :members:
+   :private-members:
+   :show-inheritance:
+
+.. automodule:: blocks.serialization
+   :undoc-members:
+   :members:
    :private-members:
    :show-inheritance:


### PR DESCRIPTION
This PR adds every non-documented class to the autobuilt documentation and fixes a few typos.
Please check if you like the way I grouped things together.