### PR TITLE
Add data consistency check for VariableFilter

### DIFF
--- a/blocks/search.py
+++ b/blocks/search.py
@@ -111,7 +111,7 @@ class BeamSearch(object):
                                       roles=[OUTPUT])(self.inner_cg)[-1]
                        for name in self.state_names]
         next_outputs = VariableFilter(
-            applications=self.generator.readout.emit, roles=[OUTPUT])(
+            applications=[self.generator.readout.emit], roles=[OUTPUT])(
                 self.inner_cg.variables)
         self.next_state_computer = function(
             self.contexts + self.input_states + next_outputs, next_states)
@@ -121,7 +121,7 @@ class BeamSearch(object):
         # (in terms of computations) variables, and we do not care
         # which to use.
         probs = VariableFilter(
-            applications=self.generator.readout.emitter.probs,
+            applications=[self.generator.readout.emitter.probs],
             roles=[OUTPUT])(self.inner_cg)[0]
         logprobs = -tensor.log(probs)
         self.logprobs_computer = function(

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -204,10 +204,10 @@ def main(mode, save_path, num_batches, data_path=None):
         # Fetch variables useful for debugging
         generator = reverser.generator
         (energies,) = VariableFilter(
-            applications=generator.readout.readout,
+            applications=[generator.readout.readout],
             name_regex="output")(cg.variables)
         (activations,) = VariableFilter(
-            applications=generator.transition.apply,
+            applications=[generator.transition.apply],
             name=generator.transition.apply.states[0])(cg.variables)
         max_length = named_copy(chars.shape[0], "max_length")
         cost_per_character = named_copy(

--- a/tests/bricks/test_recurrent.py
+++ b/tests/bricks/test_recurrent.py
@@ -304,7 +304,7 @@ def test_saved_inner_graph():
     cg = ComputationGraph(application_call.inner_outputs)
     # Check that the inner scan graph is annotated
     # with `recurrent.apply`
-    assert len(VariableFilter(applications=recurrent.apply)(cg)) == 3
+    assert len(VariableFilter(applications=[recurrent.apply])(cg)) == 3
     # Check that the inner graph is equivalent to the one
     # produced by a stand-alone of `recurrent.apply`
     assert is_same_graph(application_call.inner_outputs[0],

--- a/tests/test_variable_filter.py
+++ b/tests/test_variable_filter.py
@@ -44,7 +44,7 @@ def test_variable_filter():
     assert brick1_bias == brick_filter(cg.variables)
 
     # Testing filtering by brick instance
-    brick_filter = VariableFilter(roles=[BIAS], bricks=brick1)
+    brick_filter = VariableFilter(roles=[BIAS], bricks=[brick1])
     assert brick1_bias == brick_filter(cg.variables)
 
     # Testing filtering by name
@@ -56,7 +56,7 @@ def test_variable_filter():
     assert [cg.variables[2]] == name_filter_regex(cg.variables)
 
     # Testing filtering by application
-    appli_filter = VariableFilter(applications=brick1.apply)
+    appli_filter = VariableFilter(applications=[brick1.apply])
     variables = [cg.variables[1], cg.variables[8]]
     assert variables == appli_filter(cg.variables)
 

--- a/tests/test_variable_filter.py
+++ b/tests/test_variable_filter.py
@@ -1,3 +1,5 @@
+from nose.tools import raises
+
 from blocks.bricks import Bias, Linear, Sigmoid
 from blocks.filter import VariableFilter
 from blocks.graph import ComputationGraph
@@ -63,3 +65,26 @@ def test_variable_filter():
     # Testing filtering by application
     appli_filter_list = VariableFilter(applications=[brick1.apply])
     assert variables == appli_filter_list(cg.variables)
+
+
+@raises(TypeError)
+def test_variable_filter_roles_error():
+    # Creating computation graph
+    brick1 = Linear(input_dim=2, output_dim=2, name='linear1')
+
+    x = tensor.vector()
+    h1 = brick1.apply(x)
+    cg = ComputationGraph(h1)
+    # testing role error
+    VariableFilter(roles=PARAMETER)(cg.variables)
+
+
+@raises(TypeError)
+def test_variable_filter_applications_error():
+    # Creating computation graph
+    brick1 = Linear(input_dim=2, output_dim=2, name='linear1')
+
+    x = tensor.vector()
+    h1 = brick1.apply(x)
+    cg = ComputationGraph(h1)
+    VariableFilter(applications=brick1.apply)(cg.variables)


### PR DESCRIPTION
This PR checks the input consistency of `roles` and `applications`.

I know it's borderline wrt the duck typing philosophy, but currently `VariableFilter` is not failing when for instance `bricks` is a list of lists (e.g. `bricks=[MLP.children]`). I guess duck typing is great if you also catch the errors as soon as possible, because silent fails are a pain to debug. :) Let me know if there is a better way to enforce input consistency though.