### PR TITLE
Fix division by zero in attention

### DIFF
--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -227,7 +227,7 @@ class GenericSequenceAttention(AbstractAttention):
         unormalized_weights = tensor.exp(energies)
         if attended_mask:
             unormalized_weights *= attended_mask
-        return unormalized_weights / unormalized_weights.sum(axis=0)
+        return unormalized_weights / (unormalized_weights.sum(axis=0) + 1e-5)
 
     @application
     def compute_weighted_averages(self, weights, attended):

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -42,7 +42,6 @@ are the glimpses. A generalized attention mechanism for this paper is
 represented here as :class:`SequenceContentAttention`.
 
 """
-import numpy
 from abc import ABCMeta, abstractmethod
 
 from theano import tensor
@@ -228,8 +227,11 @@ class GenericSequenceAttention(AbstractAttention):
         unnormalized_weights = tensor.exp(energies)
         if attended_mask:
             unnormalized_weights *= attended_mask
-        return unnormalized_weights / (unnormalized_weights.sum(axis=0) +
-                                       numpy.finfo('float32').tiny)
+
+        # If mask consists of all zeros use 1 as the normalization coefficient
+        normalization = (unnormalized_weights.sum(axis=0) +
+                         tensor.all(1 - attended_mask, axis=0))
+        return unnormalized_weights / normalization
 
     @application
     def compute_weighted_averages(self, weights, attended):

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -42,6 +42,7 @@ are the glimpses. A generalized attention mechanism for this paper is
 represented here as :class:`SequenceContentAttention`.
 
 """
+import numpy
 from abc import ABCMeta, abstractmethod
 
 from theano import tensor
@@ -224,10 +225,11 @@ class GenericSequenceAttention(AbstractAttention):
             as `energies`.
 
         """
-        unormalized_weights = tensor.exp(energies)
+        unnormalized_weights = tensor.exp(energies)
         if attended_mask:
-            unormalized_weights *= attended_mask
-        return unormalized_weights / (unormalized_weights.sum(axis=0) + 1e-5)
+            unnormalized_weights *= attended_mask
+        return unnormalized_weights / (unnormalized_weights.sum(axis=0) +
+                                       numpy.finfo('float32').tiny)
 
     @application
     def compute_weighted_averages(self, weights, attended):

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -235,7 +235,7 @@ class ConvolutionalLayer(Sequence, Initializable):
     --------
     :class:`Convolutional` : Documentation of convolution arguments.
     :class:`MaxPooling` : Documentation of pooling arguments.
-    
+
     Notes
     -----
     Uses max pooling.

--- a/tests/bricks/test_attention.py
+++ b/tests/bricks/test_attention.py
@@ -132,3 +132,25 @@ def test_attention_recurrent():
     assert_allclose(weight_vals.sum(), input_length * batch_size, 1e-5)
     assert_allclose(states_vals.sum(), 113.429, rtol=1e-5)
     assert_allclose(glimpses_vals.sum(), 415.901, rtol=1e-5)
+
+
+def test_compute_weights_with_zero_mask():
+    state_dim = 2
+    attended_dim = 3
+    match_dim = 4
+    attended_length = 5
+    batch_size = 6
+
+    attention = SequenceContentAttention(
+        state_names=["states"], state_dims=[state_dim],
+        attended_dim=attended_dim, match_dim=match_dim,
+        weights_init=IsotropicGaussian(0.5),
+        biases_init=Constant(0))
+    attention.initialize()
+
+    energies = tensor.as_tensor_variable(
+        numpy.random.rand(attended_length, batch_size))
+    mask = tensor.as_tensor_variable(
+        numpy.zeros((attended_length, batch_size)))
+    weights = attention.compute_weights(energies, mask).eval()
+    assert numpy.all(numpy.isfinite(weights))


### PR DESCRIPTION
I was developing my custom attention mechanism and came across an issue: `compute_weights` did not work with a mask consisting of all zeros. I did have such masks. This PR fixed the issue.

Also fixes a syntax error in `conv.py`