### PR TITLE
Add check in Selector.get_params for path uniqueness

### DIFF
--- a/blocks/select.py
+++ b/blocks/select.py
@@ -10,6 +10,12 @@ from blocks.utils import dict_union
 
 logger = logging.getLogger(__name__)
 
+name_collision_error_message = """
+
+The '{}' name appears more than once. Make sure that all bricks' children \
+have different names and that user-defined shared variables have unique names.
+"""
+
 
 class Path(object):
     """Encapsulates a path in a hierarchy of bricks.
@@ -179,10 +185,9 @@ class Selector(object):
                     new_path = Path([Path.BrickName(brick.name)]) + path
                     if new_path in result:
                         raise ValueError(
-                            "name collision while retrieving parameters (" +
-                            "'{}' appears more than once). ".format(new_path) +
-                            "Make sure that for all bricks, children of a "
-                            "given brick have different names.")
+                            "Name collision encountered while retrieving " +
+                            "parameters." +
+                            name_collision_error_message.format(new_path))
                     result[new_path] = param
             return result
         result = dict_union(*[recursion(brick)

--- a/blocks/select.py
+++ b/blocks/select.py
@@ -177,6 +177,12 @@ class Selector(object):
             for child in brick.children:
                 for path, param in recursion(child).items():
                     new_path = Path([Path.BrickName(brick.name)]) + path
+                    if new_path in result:
+                        raise ValueError(
+                            "name collision while retrieving parameters (" +
+                            "'{}' appears more than once). ".format(new_path) +
+                            "Make sure that for all bricks, children of a "
+                            "given brick have different names.")
                     result[new_path] = param
             return result
         result = dict_union(*[recursion(brick)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -14,6 +14,7 @@ class MockBrickTop(Brick):
         self.children = children
         self.params = []
 
+
 class MockBrickBottom(Brick):
 
     def __init__(self, **kwargs):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,9 +1,24 @@
 from copy import deepcopy
 
 import theano
+from numpy.testing import assert_raises
 
 from blocks.bricks.base import Brick
 from blocks.select import Path, Selector
+
+
+class MockBrickTop(Brick):
+
+    def __init__(self, children, **kwargs):
+        super(MockBrickTop, self).__init__(**kwargs)
+        self.children = children
+        self.params = []
+
+class MockBrickBottom(Brick):
+
+    def __init__(self, **kwargs):
+        super(MockBrickBottom, self).__init__(**kwargs)
+        self.params = [theano.shared(0, "V"), theano.shared(0, "W")]
 
 
 def test_path():
@@ -23,20 +38,16 @@ def test_path():
     assert hash(path4) != hash(path2)
 
 
+def test_selector_get_params_uniqueness():
+    top = MockBrickTop(
+        [MockBrickBottom(name="bottom"), MockBrickBottom(name="bottom")],
+        name="top")
+
+    selector = Selector([top])
+    assert_raises(ValueError, selector.get_params)
+
+
 def test_selector():
-    class MockBrickTop(Brick):
-
-        def __init__(self, children, **kwargs):
-            super(MockBrickTop, self).__init__(**kwargs)
-            self.children = children
-            self.params = []
-
-    class MockBrickBottom(Brick):
-
-        def __init__(self, **kwargs):
-            super(MockBrickBottom, self).__init__(**kwargs)
-            self.params = [theano.shared(0, "V"), theano.shared(0, "W")]
-
     b1 = MockBrickBottom(name="b1")
     b2 = MockBrickBottom(name="b2")
     b3 = MockBrickBottom(name="b3")


### PR DESCRIPTION
This concerns issue #480. It's not a complete solution, but at least `Selector` won't do the wrong thing silently anymore.