### PR TITLE
Clear __init__.py

### DIFF
--- a/blocks/__init__.py
+++ b/blocks/__init__.py
@@ -1,2 +1,4 @@
 """The blocks library for parametrized Theano ops."""
+# Scary warning: Adding code to this file can break namespace packages
+# See https://pythonhosted.org/setuptools/setuptools.html#namespace-packages
 __version__ = '0.1a1'

--- a/blocks/__init__.py
+++ b/blocks/__init__.py
@@ -1,17 +1,2 @@
 """The blocks library for parametrized Theano ops."""
-import os.path
-from pkg_resources import get_distribution, DistributionNotFound
-
-from blocks.config_parser import config  # noqa
-
-
-try:
-    DIST = get_distribution('blocks')
-    DIST_LOC = os.path.normcase(DIST.location)
-    HERE = os.path.normcase(__file__)
-    if not HERE.startswith(os.path.join(DIST_LOC, 'blocks')):
-        raise DistributionNotFound
-except DistributionNotFound:
-    __version__ = 'not installed'
-else:
-    __version__ = DIST.version
+__version__ = '0.1a1'

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -8,7 +8,7 @@ from theano.sandbox.rng_mrg import MRG_RandomStreams
 from toolz import interleave
 from picklable_itertools.extras import equizip
 
-from blocks import config
+from blocks.config import config
 from blocks.bricks.base import application, _Brick, Brick, lazy
 from blocks.roles import add_role, WEIGHT, BIAS
 from blocks.utils import pack, shared_floatx_nans

--- a/blocks/config.py
+++ b/blocks/config.py
@@ -17,9 +17,9 @@ If a setting is not configured and does not provide a default, a
 accessed.
 
 Configuration values can be accessed as attributes of
-:const:`blocks.config`.
+:const:`blocks.config.config`.
 
-    >>> from blocks import config
+    >>> from blocks.config import config
     >>> print(config.default_seed) # doctest: +SKIP
     1
 

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -11,7 +11,7 @@ except ImportError:
     BOKEH_AVAILABLE = False
 
 
-from blocks import config
+from blocks.config import config
 from blocks.extensions import SimpleExtension
 
 logger = logging.getLogger(__name__)

--- a/blocks/graph.py
+++ b/blocks/graph.py
@@ -11,7 +11,7 @@ from theano.sandbox.rng_mrg import MRG_RandomStreams
 from theano.scan_module.scan_op import Scan
 from toolz import unique
 
-from blocks import config
+from blocks.config import config
 from blocks.roles import add_role, has_roles, AUXILIARY, PARAMETER, DROPOUT
 from blocks.utils import (is_graph_input, is_shared_variable, dict_union,
                           shared_like)

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -3,7 +3,7 @@ import signal
 import logging
 import traceback
 
-from blocks import config
+from blocks.config import config
 from blocks.log import TrainingLog
 from blocks.utils import reraise_as, unpack, change_recursion_limit
 from blocks.utils.profile import Profile, Timer

--- a/blocks/scripts/__init__.py
+++ b/blocks/scripts/__init__.py
@@ -2,7 +2,7 @@ import os.path
 
 from six.moves import cPickle
 
-from blocks import config
+from blocks.config import config
 from blocks.dump import MainLoopDumpManager
 from blocks.utils import change_recursion_limit
 

--- a/blocks/scripts/plot.py
+++ b/blocks/scripts/plot.py
@@ -8,7 +8,7 @@ from six.moves import cPickle
 from collections import OrderedDict
 from functools import reduce
 
-from blocks import config
+from blocks.config import config
 from blocks.utils import change_recursion_limit
 from blocks.log import TrainingLog
 from blocks.main_loop import MainLoop

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,7 +1,7 @@
 Configuration
 =============
 
-.. automodule:: blocks.config_parser
+.. automodule:: blocks.config
 
 .. autoclass:: ConfigurationError
    :show-inheritance:

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -19,7 +19,7 @@ from blocks.bricks.attention import SequenceContentAttention
 from blocks.bricks.parallel import Fork
 from blocks.bricks.sequence_generators import (
     SequenceGenerator, Readout, SoftmaxEmitter, LookupFeedback)
-from blocks.config_parser import config
+from blocks.config import config
 from blocks.graph import ComputationGraph
 from fuel.transformers import Mapping, Batch, Padding, Filter
 from fuel.datasets import OneBillionWord, TextFile

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import blocks
 from codecs import open
 from os import path
 from setuptools import find_packages, setup
@@ -11,7 +12,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='blocks',
-    version='0.1a1',  # PEP 440 compliant
+    version=blocks.__version__,  # PEP 440 compliant
     description='A Theano framework for building and training neural networks',
     long_description=long_description,
     url='https://github.com/bartvm/blocks',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,7 +8,7 @@ from unittest.case import SkipTest
 from six import StringIO
 
 import blocks
-from blocks import config
+from blocks.config import config
 from blocks.main_loop import MainLoop
 from fuel.datasets import IterableDataset
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,10 +3,10 @@ import tempfile
 
 from numpy.testing import assert_raises
 
-from blocks.config_parser import Configuration, ConfigurationError
+from blocks.config import Configuration, ConfigurationError
 
 
-def test_config_parser():
+def test_config():
     _environ = dict(os.environ)
     try:
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -4,6 +4,7 @@ import tempfile
 from six.moves import cPickle
 
 import blocks
+from blocks.config import config
 from blocks.extensions.saveload import SAVED_TO
 from examples.sqrt import main as sqrt_test
 from examples.mnist import main as mnist_test
@@ -42,12 +43,12 @@ def test_markov_chain():
 @silence_printing
 def test_reverse_words():
     skip_if_not_available(modules=['bokeh'])
-    old_limit = blocks.config.recursion_limit
-    blocks.config.recursion_limit = 100000
+    old_limit = config.recursion_limit
+    config.recursion_limit = 100000
     with tempfile.NamedTemporaryFile() as f_save,\
             tempfile.NamedTemporaryFile() as f_data:
         with open(f_data.name, 'wt') as data:
             for i in range(10):
                 print("A line.", file=data)
         reverse_words_test("train", f_save.name, 1, [f_data.name])
-    blocks.config.recursion_limit = old_limit
+    config.recursion_limit = old_limit

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,7 +3,6 @@ import tempfile
 
 from six.moves import cPickle
 
-import blocks
 from blocks.config import config
 from blocks.extensions.saveload import SAVED_TO
 from examples.sqrt import main as sqrt_test


### PR DESCRIPTION
In order to make https://github.com/mila-udem/blocks-extras work as a namespace package, the `__init__.py` file needs to be entirely cleared (see https://pythonhosted.org/setuptools/setuptools.html#namespace-packages).

To make this work:

* Set `__version__` in `__init__.py` instead of loading it with `pkg_resources`
* Move `blocks.config` to `blocks.config.config`. Not as clean, but there's not other way I can think of without programmatically changing the namespace, and I find that a bit too messy. 