### PR TITLE
Fix default value of requires in MonitoredQuantity

### DIFF
--- a/blocks/monitoring/aggregation.py
+++ b/blocks/monitoring/aggregation.py
@@ -191,7 +191,7 @@ class MonitoredQuantity(object):
 
     """
     def __init__(self, requires=None, name=None):
-        self.requires = requires
+        self.requires = requires if (requires is not None) else []
         self.name = name
 
     @abstractmethod

--- a/blocks/monitoring/aggregation.py
+++ b/blocks/monitoring/aggregation.py
@@ -191,7 +191,9 @@ class MonitoredQuantity(object):
 
     """
     def __init__(self, requires=None, name=None):
-        self.requires = requires if (requires is not None) else []
+        if requires is None:
+            requires = []
+        self.requires = requires
         self.name = name
 
     @abstractmethod


### PR DESCRIPTION
MonitoredQuantityBuffer assumes requires to be a list (at
monitoring/evaluators.py:45), so the default should be a list, not None.

I have not tested the problem nor the solution; just fixed it while reading
the code.